### PR TITLE
#19 Fix the Windows race condition in the measurement file by using one file per thread.

### DIFF
--- a/src/main/scala/scoverage/IOUtils.scala
+++ b/src/main/scala/scoverage/IOUtils.scala
@@ -7,12 +7,12 @@ object IOUtils {
 
   // loads all the invoked statement ids
   def invoked(dir: File): Seq[Int] = {
-    dir.listFiles.map(file => {
+    dir.listFiles.flatMap { file =>
       val reader = new BufferedReader(new FileReader(file))
       val line = reader.readLine()
       reader.close()
       line.split(";").filterNot(_.isEmpty).map(_.toInt)
-    }).flatten.toSeq
+    }
   }
 
   def serialize(coverage: Coverage, file: File) {

--- a/src/main/scala/scoverage/plugin.scala
+++ b/src/main/scala/scoverage/plugin.scala
@@ -76,7 +76,6 @@ class ScoverageComponent(val global: Global, options: ScoverageOptions)
     def safeSource(tree: Tree): Option[SourceFile] = if (tree.pos.isDefined) Some(tree.pos.source) else None
 
     def invokeCall(id: Int): Tree = {
-      val file = Env.measurementFile(options.dataDir).getAbsolutePath
       Apply(
         Select(
           Select(
@@ -90,7 +89,7 @@ class ScoverageComponent(val global: Global, options: ScoverageOptions)
             Constant(id)
           ),
           Literal(
-            Constant(file)
+            Constant(getMeasurementFilesPath())
           )
         )
       )
@@ -138,6 +137,20 @@ class ScoverageComponent(val global: Global, options: ScoverageOptions)
           val block = Block(List(apply), tree)
           localTyper.typed(atPos(tree.pos)(block))
       }
+    }
+
+    /**
+     * Get the configured dir in which the measurement files should be written
+     * (see [[Invoker.invoked()]])
+     *
+     * This path will be hardcoded into the instrumented class files.
+     *
+     * We create the dir now (rather than at client runtime), for efficiency.
+     */
+    def getMeasurementFilesPath(): String = {
+      val dir = Env.measurementFile(options.dataDir).getAbsoluteFile
+      dir.mkdirs()
+      dir.getPath
     }
 
     def isIncluded(t: Tree): Boolean = {

--- a/src/test/scala/scoverage/InvokerConcurrencyTest.scala
+++ b/src/test/scala/scoverage/InvokerConcurrencyTest.scala
@@ -1,0 +1,51 @@
+package scoverage
+
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfter
+import java.io.File
+import scala.concurrent._
+import scala.concurrent.duration._
+import ExecutionContext.Implicits.global
+import scala.collection.breakOut
+
+/**
+ * Verify that [[Invoker.invoked()]] is thread-safe
+ */
+class InvokerConcurrencyTest extends FunSuite with BeforeAndAfter {
+
+  val measurementFile = new File("invoker-test.measurement")
+
+  before {
+    deleteMeasurementFiles()
+  }
+
+  test("calling Invoker.invoked on multiple threads does not corrupt the measurement file") {
+
+    val testIds: Set[Int] = (1 to 1000).toSet
+
+    // Create 1k "invoked" calls on the common thread pool, to stress test
+    // the method
+    val futures: List[Future[Unit]] = testIds.map { i: Int =>
+      future {
+        Invoker.invoked(i, measurementFile.toString)
+      }
+    }(breakOut)
+
+    futures.foreach(Await.result(_, 1.second))
+
+    // Now verify that the measurement file is not corrupted by loading it
+    val idsFromFile = IOUtils.invoked(measurementFile).toSet
+
+    idsFromFile === testIds
+  }
+
+  after {
+    deleteMeasurementFiles()
+  }
+
+  private def deleteMeasurementFiles(): Unit = {
+    measurementFile.getAbsoluteFile.getParentFile.listFiles()
+      .filter(_.getName.startsWith(measurementFile.getName))
+      .foreach(_.delete())
+  }
+}


### PR DESCRIPTION
See #19
