### PR TITLE
Don't reopen the coverage file each time; on windows that is very slow.

### DIFF
--- a/src/main/scala/scoverage/IOUtils.scala
+++ b/src/main/scala/scoverage/IOUtils.scala
@@ -14,10 +14,13 @@ object IOUtils {
   def clean(dataDir: String): Unit = clean(new File(dataDir))
 
   def coverageFile(dataDir: File): File = coverageFile(dataDir.getAbsolutePath)
-  def coverageFile(dataDir: String): File = new File(dataDir + "/" + CoverageFileName)
+  def coverageFile(dataDir: String): File = new File(dataDir, CoverageFileName)
 
+  /**
+   * @return the measurement file for the current thread.
+   */
   def measurementFile(dataDir: File): File = measurementFile(dataDir.getAbsolutePath)
-  def measurementFile(dataDir: String): File = new File(dataDir + "/" + MeasurementsPrefix + Thread.currentThread.getId)
+  def measurementFile(dataDir: String): File = new File(dataDir, MeasurementsPrefix + Thread.currentThread.getId)
 
   def findMeasurementFiles(dataDir: String): Array[File] = findMeasurementFiles(new File(dataDir))
   def findMeasurementFiles(dataDir: File): Array[File] = dataDir.listFiles(new FileFilter {


### PR DESCRIPTION
This patch uses `ThreadLocal`s to avoid re-opening the coverage file on each executed statement.
"`flush()`" is used so that the coverage file is still always up-to-date, even if the instrumented JVM is abruptly killed.

On my windows machine, this took a `sbt clean scoverage:test` from 10m52 to 6m20 and a `sbt scoverage:test` with no clean (after a previous scoverage run) from 8m36 to 3m22. I think these numbers may overstate the benefit of this change (the length of the runs stops me from doing enough runs to get a good sized sample), but I do think this helps a lot with performance.
