### PR TITLE
Don't scan all statements on each hit -- there may be very many of them

### DIFF
--- a/src/test/scala/scoverage/CoverageTest.scala
+++ b/src/test/scala/scoverage/CoverageTest.scala
@@ -21,9 +21,9 @@ class CoverageTest extends FunSuite with BeforeAndAfter with OneInstancePerTest 
   test("coverage for invoked statements") {
     val coverage = Coverage()
     coverage.add(MeasuredStatement("", Location("", "", ClassType.Object, ""), 1, 2, 3, 4, "", "", "", false, 3))
-    coverage.add(MeasuredStatement("", Location("", "", ClassType.Object, ""), 1, 2, 3, 4, "", "", "", false, 0))
-    coverage.add(MeasuredStatement("", Location("", "", ClassType.Object, ""), 1, 2, 3, 4, "", "", "", false, 0))
-    coverage.add(MeasuredStatement("", Location("", "", ClassType.Object, ""), 1, 2, 3, 4, "", "", "", false, 0))
+    coverage.add(MeasuredStatement("", Location("", "", ClassType.Object, ""), 2, 2, 3, 4, "", "", "", false, 0))
+    coverage.add(MeasuredStatement("", Location("", "", ClassType.Object, ""), 3, 2, 3, 4, "", "", "", false, 0))
+    coverage.add(MeasuredStatement("", Location("", "", ClassType.Object, ""), 4, 2, 3, 4, "", "", "", false, 0))
     assert(0.25 === coverage.statementCoverage)
   }
 }


### PR DESCRIPTION
If we store the statements in a hash-map by id, then we can do a hash lookup when matching invocation ids to statement objects, rather than a "find" which needs to scan all statements.

This takes my test run (`sbt scoverage:test`, without a "clean") from 3m22 to 1m28. This number may overstate the improvement; I haven't done very many tests.
