### PR TITLE
Fix statement id overriding in CoverageAggregator

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
@@ -18,15 +18,16 @@ object CoverageAggregator {
     }
   }
 
-   def aggregatedCoverage(files: Seq[File]): Coverage = {
+  def aggregatedCoverage(files: Seq[File]): Coverage = {
     var id = 0
     val coverage = Coverage()
-    files foreach {
-      case file =>
-        val subcoverage = ScoverageXmlReader.read(file)
+    files foreach { file =>
+      val subcoverage = ScoverageXmlReader.read(file)
+      subcoverage.statements foreach { stmt =>
         // need to ensure all the ids are unique otherwise the coverage object will have stmt collisions
         id = id + 1
-        subcoverage.statements foreach { stmt => coverage add stmt.copy(id = id)}
+        coverage add stmt.copy(id = id)
+      }
     }
     coverage
   }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageAggregatorTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageAggregatorTest.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.util.UUID
 
 import org.scalatest.{FreeSpec, Matchers}
-import scoverage.report.{ScoverageXmlWriter, CoverageAggregator}
+import scoverage.report.{CoverageAggregator, ScoverageXmlWriter}
 
 class CoverageAggregatorTest extends FreeSpec with Matchers {
 
@@ -20,7 +20,8 @@ class CoverageAggregatorTest extends FreeSpec with Matchers {
         source)
 
       val coverage1 = Coverage()
-      coverage1.add(Statement(source, location, 1, 155, 176, 4, "", "", "", true, 2))
+      coverage1.add(Statement(source, location, 1, 155, 176, 4, "", "", "", true, 1))
+      coverage1.add(Statement(source, location, 2, 200, 300, 5, "", "", "", false, 2))
       val dir1 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
       dir1.mkdir()
       new ScoverageXmlWriter(new File("/home/sam"), dir1, false).write(coverage1)
@@ -42,7 +43,7 @@ class CoverageAggregatorTest extends FreeSpec with Matchers {
           IOUtils.reportFile(dir2, debug = false),
           IOUtils.reportFile(dir3, debug = false))
       )
-      aggregated.statements.toSet.size shouldBe 3
+      aggregated.statements.toSet.size shouldBe 4
       aggregated.statements.map(_.copy(id = 0)).toSet shouldBe
         (coverage1.statements ++ coverage2.statements ++ coverage3.statements).map(_.copy(id = 0)).toSet
     }


### PR DESCRIPTION
Incrementation of `id` should be nested in statements loop, otherwise it adds only one (last) statement per module. This is probably related to https://github.com/scoverage/sbt-scoverage/issues/64
