### PR TITLE
Standardise use of CanonicalPath

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -23,7 +23,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
     coverage.packages.foreach(writePackage)
   }
 
-  private def relativeSource(src: String): String = src.replace(sourceDirectory.getAbsolutePath + File.separator, "")
+  private def relativeSource(src: String): String = src.replace(sourceDirectory.getCanonicalPath + File.separator, "")
 
   private def writePackage(pkg: MeasuredPackage): Unit = {
     // package overview files are written out using a filename that respects the package name


### PR DESCRIPTION
Location.scala uses AbstractFile.canonicalPath while
ScoverageHtmlWriter.scala uses java.io.File.getAbsolutePath for file
paths. This mean that there is a possibility (esp. Windows environment)
that creation of reports will fail because the scoverage.coverage.xml
created will contain paths with an upper case drive letter while
ScoverageHtmlWriter will be using paths with a lower case drive letter.

Addresses issue #74
