### PR TITLE
Correct issue with line double spacing / highlighting in Code Grid view on Windows

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CodeGrid.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CodeGrid.scala
@@ -9,7 +9,7 @@ class CodeGrid(mfile: MeasuredFile) {
 
   case class Cell(char: Char, var status: StatementStatus)
 
-  private val lineBreak = System.getProperty("line.separator").toCharArray
+  private val lineBreak = System.getProperty("line.separator")
 
   // note: we must reinclude the line sep to keep source positions correct.
   private val lines = source(mfile).split(lineBreak).map(line => (line.toCharArray ++ lineBreak).map(Cell(_, NoData)))


### PR DESCRIPTION
I observed that on Windows systems, the highlighting is off on the code grid view due to an issue with the incorrect `.split` method being invoked on the source file (String). This results in a "double spacing" effect in addition to the incorrect highlighting.

The actual `.split` method being invoked is `StringLike.split`, which translates into a regex `[\r\n]` which is then passed to the Java String.split method. The behavior of this method will cause 2 lines in the resultant array.

Issue is resolved if treating as a single String (and not a Char array), which will invoke the Java `String.split(String regex)` method, and correctly treat the "\r\n" as a single expression. This should work correctly on other platforms with a single character line ending (Unix and Mac).

After looking at the history of this file, it seems you may have had a similar issue in the past... without knowing the history, I will let you determine the best fix :) but I have verified that this does correct the behavior I was seeing with a local snapshot build of the plugin.

FWIW I encountered this issue with Scala 2.11.4, I haven't tested the fix with 2.10. Please have a look and let me know what else needs to be done to make this a good pull?