### PR TITLE
Bugfix/locale dependent tests

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/IOUtils.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/IOUtils.scala
@@ -2,8 +2,6 @@ package scoverage
 
 import java.io._
 
-import scoverage.report.ScoverageXmlMerger
-
 import scala.collection.{Set, mutable}
 import scala.io.Source
 

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/coverage.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/coverage.scala
@@ -113,13 +113,11 @@ object ClassType {
   }
 }
 
-
-
-
 case class ClassRef(name: String) {
   lazy val simpleName = name.split(".").last
   lazy val getPackage = name.split(".").dropRight(1).mkString(".")
 }
+
 object ClassRef {
   def fromFilepath(path: String) = ClassRef(path.replace('/', '.'))
   def apply(_package: String, className: String): ClassRef = ClassRef(_package.replace('/', '.') + "." + className)

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
@@ -31,7 +31,7 @@ class ScoveragePlugin(val global: Global) extends Plugin {
       }
     }
     if (!opts.exists(_.startsWith("dataDir:")))
-      throw new RuntimeException("Cannot invoke plugin without specifiying <dataDir>")
+      throw new RuntimeException("Cannot invoke plugin without specifying <dataDir>")
     instrumentationComponent.setOptions(options)
   }
 
@@ -315,7 +315,7 @@ class ScoverageInstrumentationComponent(val global: Global)
             c
           }
 
-        // scalac generated classes, we just instrument the enclosed methods/statments
+        // scalac generated classes, we just instrument the enclosed methods/statements
         // the location would stay as the source class
         case c: ClassDef if c.symbol.isAnonymousClass || c.symbol.isAnonymousFunction =>
           if (isFileIncluded(c.pos.source) && isClassIncluded(c.symbol))
@@ -336,7 +336,7 @@ class ScoverageInstrumentationComponent(val global: Global)
         case DefDef(mods, _, _, _, _, _) if mods.isMacro => tree
 
         // this will catch methods defined as macros, eg def test = macro testImpl
-        // it will not catch macro implemenations
+        // it will not catch macro implementations
         case d: DefDef if d.symbol != null
           && d.symbol.annotations.size > 0
           && d.symbol.annotations.toString() == "macroImpl" =>
@@ -415,13 +415,13 @@ class ScoverageInstrumentationComponent(val global: Global)
 
         // the If statement itself doesn't need to be instrumented, because instrumenting the condition is
         // enough to determine if the If statement was executed.
-        // The two procedures (then and else) are instrumented seperately to determine if we entered
+        // The two procedures (then and else) are instrumented separately to determine if we entered
         // both branches.
         case i: If =>
           treeCopy.If(i,
             process(i.cond),
-            instrument(process(i.thenp), i.thenp, true),
-            instrument(process(i.elsep), i.elsep, true))
+            instrument(process(i.thenp), i.thenp, branch = true),
+            instrument(process(i.elsep), i.elsep, branch = true))
 
         case _: Import => tree
 
@@ -533,9 +533,12 @@ class ScoverageInstrumentationComponent(val global: Global)
         // This AST node corresponds to the following Scala code: expr: tpt
         case t: Typed => super.transform(tree)
 
-        // instrument trys, catches and finally as seperate blocks
+        // instrument trys, catches and finally as separate blocks
         case Try(t: Tree, cases: List[CaseDef], f: Tree) =>
-          treeCopy.Try(tree, instrument(process(t), t, true), transformCases(cases), instrument(process(f), f, true))
+          treeCopy.Try(tree,
+            instrument(process(t), t, branch = true),
+            transformCases(cases),
+            instrument(process(f), f, branch = true))
 
         // type aliases, type parameters, abstract types
         case t: TypeDef => super.transform(tree)

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CodeGrid.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CodeGrid.scala
@@ -1,30 +1,30 @@
 package scoverage.report
 
+import _root_.scoverage.MeasuredFile
+
 import scala.io.Source
 
-import _root_.scoverage.{MeasuredFile, Statement}
-
 /** @author Stephen Samuel */
-class CodeGrid(mfile: MeasuredFile) {
+class CodeGrid(mFile: MeasuredFile) {
 
   case class Cell(char: Char, var status: StatementStatus)
 
   private val lineBreak = System.getProperty("line.separator")
 
   // Array of lines, each line is an array of cells, where a cell is a character + coverage info for that position
-  // All cells defaul to NoData until the highlighted information is applied
-  // note: we must reinclude the line sep to keep source positions correct.
-  private val lines = source(mfile).split(lineBreak).map(line => (line.toCharArray ++ lineBreak).map(Cell(_, NoData)))
+  // All cells default to NoData until the highlighted information is applied
+  // note: we must re-include the line sep to keep source positions correct.
+  private val lines = source(mFile).split(lineBreak).map(line => (line.toCharArray ++ lineBreak).map(Cell(_, NoData)))
 
   // useful to have a single array to write into the cells
   private val cells = lines.flatten
 
   // apply the instrumentation data to the cells updating their coverage info
-  mfile.statements.foreach(stmt => {
+  mFile.statements.foreach(stmt => {
     for ( k <- stmt.start until stmt.end ) {
       if (k < cells.size) {
         // if the cell is set to Invoked, then it be changed to NotInvoked, as an inner statement will override
-        // outer containing statments. If a cell is NotInvoked then it can not be changed further.
+        // outer containing statements. If a cell is NotInvoked then it can not be changed further.
         // in that block were executed
         cells(k).status match {
           case Invoked => if (!stmt.isInvoked) cells(k).status = NotInvoked

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -156,7 +156,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
   def packageOverview(pack: MeasuredPackage): Node = {
     <html>
       {header}<body style="font-family: monospace;">
-      {classesTable(pack.classes, false)}
+      {classesTable(pack.classes, addPath = false)}
     </body>
     </html>
   }
@@ -417,7 +417,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
           {stats(coverage)}
         </div>
         <div>
-          {classesTable(coverage.classes, true)}
+          {classesTable(coverage.classes, addPath = true)}
         </div>
       </div>
     </body>

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlReader.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlReader.scala
@@ -16,7 +16,7 @@ object ScoverageXmlReader {
 
     var id = 0
     val coverage = Coverage()
-    (xml \\ "statement") foreach { node => {
+    (xml \\ "statement") foreach { node =>
 
       val source = node \ "@source"
       val pkg = node \ "@package"
@@ -54,7 +54,6 @@ object ScoverageXmlReader {
         branch.text.toBoolean,
         count.text.toInt
       )
-    }
     }
     coverage
   }

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/StatementWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/StatementWriter.scala
@@ -5,7 +5,7 @@ import _root_.scoverage.MeasuredFile
 import scala.xml.Node
 
 /** @author Stephen Samuel */
-class StatementWriter(mfile: MeasuredFile) {
+class StatementWriter(mFile: MeasuredFile) {
 
   val GREEN = "#AEF1AE"
   val RED = "#F0ADAD"
@@ -25,7 +25,7 @@ class StatementWriter(mfile: MeasuredFile) {
         <th>Tree</th>
         <th>Symbol</th>
         <th>Code</th>
-      </tr>{mfile.statements.toSeq.sortBy(_.line).map(stmt => {
+      </tr>{mFile.statements.toSeq.sortBy(_.line).map(stmt => {
       <tr>
         <td>
           {stmt.line}

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
@@ -1,7 +1,7 @@
 package scoverage
 
 import java.io.File
-import java.util.UUID
+import java.util.{Locale, UUID}
 import javax.xml.parsers.DocumentBuilderFactory
 
 import org.scalatest.{BeforeAndAfter, FunSuite, OneInstancePerTest}
@@ -97,8 +97,10 @@ class CoberturaXmlWriterTest extends FunSuite with BeforeAndAfter with OneInstan
 
     val xml = XML.loadFile(fileIn(dir))
 
-    assert(xml \\ "coverage" \@ "line-rate" === "0.33", "line-rate")
-    assert(xml \\ "coverage" \@ "branch-rate" === "0.50", "branch-rate")
+    def formattedLocally(decimal: BigDecimal) = "%.2f".format(decimal)
+
+    assert(xml \\ "coverage" \@ "line-rate" === formattedLocally(0.33), "line-rate")
+    assert(xml \\ "coverage" \@ "branch-rate" === formattedLocally(0.50), "branch-rate")
 
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
@@ -62,19 +62,16 @@ class CoberturaXmlWriterTest extends FunSuite with BeforeAndAfter with OneInstan
     builder.setErrorHandler(new ErrorHandler() {
       @Override
       def error(e: SAXParseException) {
-        e.printStackTrace()
-        assert(false)
+        fail(e)
       }
       @Override
       def fatalError(e: SAXParseException) {
-        e.printStackTrace()
-        assert(false)
+        fail(e)
       }
 
       @Override
       def warning(e: SAXParseException) {
-        e.printStackTrace()
-        assert(false)
+        fail(e)
       }
     })
     builder.parse(fileIn(dir))

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/IOUtilsTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/IOUtilsTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest}
 class IOUtilsTest extends FreeSpec with MockitoSugar with OneInstancePerTest with Matchers {
 
   "io utils" - {
-    "should parse measurment files" in {
+    "should parse measurement files" in {
       val file = File.createTempFile("scoveragemeasurementtest", "txt")
       val writer = new FileWriter(file)
       writer.write("1\n5\n9\n\n10\n")

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/LocationTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/LocationTest.scala
@@ -9,7 +9,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for classes" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.test\nclass Sammy")
-        val loc = compiler.locations.result.find(_._1 == "Template").get._2
+        val loc = compiler.locations.result().find(_._1 == "Template").get._2
         loc.packageName shouldBe "com.test"
         loc.className shouldBe "Sammy"
         loc.topLevelClass shouldBe "Sammy"
@@ -20,7 +20,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for objects" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.test\nobject Bammy { def foo = 'boo } ")
-        val loc = compiler.locations.result.find(_._1 == "Template").get._2
+        val loc = compiler.locations.result().find(_._1 == "Template").get._2
         loc.packageName shouldBe "com.test"
         loc.className shouldBe "Bammy"
         loc.topLevelClass shouldBe "Bammy"
@@ -31,7 +31,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for traits" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.test\ntrait Gammy { def goo = 'hoo } ")
-        val loc = compiler.locations.result.find(_._1 == "Template").get._2
+        val loc = compiler.locations.result().find(_._1 == "Template").get._2
         loc.packageName shouldBe "com.test"
         loc.className shouldBe "Gammy"
         loc.topLevelClass shouldBe "Gammy"
@@ -43,7 +43,7 @@ class LocationTest extends FreeSpec with Matchers {
     "should correctly process methods" in {
       val compiler = ScoverageCompiler.locationCompiler
       compiler.compile("package com.methodtest \n class Hammy { def foo = 'boo } ")
-      val loc = compiler.locations.result.find(_._2.method == "foo").get._2
+      val loc = compiler.locations.result().find(_._2.method == "foo").get._2
       loc.packageName shouldBe "com.methodtest"
       loc.className shouldBe "Hammy"
       loc.classType shouldBe ClassType.Class
@@ -52,7 +52,7 @@ class LocationTest extends FreeSpec with Matchers {
     "should correctly process nested methods" in {
       val compiler = ScoverageCompiler.locationCompiler
       compiler.compile("package com.methodtest \n class Hammy { def foo = { def goo = { getClass; 3 }; goo } } ")
-      val loc = compiler.locations.result.find(_._2.method == "goo").get._2
+      val loc = compiler.locations.result().find(_._2.method == "goo").get._2
       loc.packageName shouldBe "com.methodtest"
       loc.className shouldBe "Hammy"
       loc.topLevelClass shouldBe "Hammy"
@@ -63,7 +63,7 @@ class LocationTest extends FreeSpec with Matchers {
     "should process anon functions as inside the enclosing method" in {
       val compiler = ScoverageCompiler.locationCompiler
       compiler.compile("package com.methodtest \n class Jammy { def moo = { Option(\"bat\").map(_.length) } } ")
-      val loc = compiler.locations.result.find(_._1 == "Function").get._2
+      val loc = compiler.locations.result().find(_._1 == "Function").get._2
       loc.packageName shouldBe "com.methodtest"
       loc.className shouldBe "Jammy"
       loc.method shouldBe "moo"
@@ -74,7 +74,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for nested classes" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.methodtest \n class Jammy { class Pammy } ")
-        val loc = compiler.locations.result.find(_._2.className == "Pammy").get._2
+        val loc = compiler.locations.result().find(_._2.className == "Pammy").get._2
         loc.packageName shouldBe "com.methodtest"
         loc.className shouldBe "Pammy"
         loc.topLevelClass shouldBe "Jammy"
@@ -85,7 +85,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for nested objects" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.methodtest \n class Jammy { object Zammy } ")
-        val loc = compiler.locations.result.find(_._2.className == "Zammy").get._2
+        val loc = compiler.locations.result().find(_._2.className == "Zammy").get._2
         loc.packageName shouldBe "com.methodtest"
         loc.className shouldBe "Zammy"
         loc.topLevelClass shouldBe "Jammy"
@@ -96,7 +96,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for nested traits" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.methodtest \n class Jammy { trait Mammy } ")
-        val loc = compiler.locations.result.find(_._2.className == "Mammy").get._2
+        val loc = compiler.locations.result().find(_._2.className == "Mammy").get._2
         loc.packageName shouldBe "com.methodtest"
         loc.className shouldBe "Mammy"
         loc.topLevelClass shouldBe "Jammy"
@@ -111,7 +111,7 @@ class LocationTest extends FreeSpec with Matchers {
         compiler.compile("package com.a \n " +
           "package b \n" +
           "class Kammy ")
-        val loc = compiler.locations.result.find(_._1 == "Template").get._2
+        val loc = compiler.locations.result().find(_._1 == "Template").get._2
         loc.packageName shouldBe "com.a.b"
         loc.className shouldBe "Kammy"
         loc.topLevelClass shouldBe "Kammy"
@@ -124,7 +124,7 @@ class LocationTest extends FreeSpec with Matchers {
         compiler.compile("package com.a \n " +
           "package b \n" +
           "object Kammy ")
-        val loc = compiler.locations.result.find(_._1 == "Template").get._2
+        val loc = compiler.locations.result().find(_._1 == "Template").get._2
         loc.packageName shouldBe "com.a.b"
         loc.className shouldBe "Kammy"
         loc.method shouldBe "<none>"
@@ -136,7 +136,7 @@ class LocationTest extends FreeSpec with Matchers {
         compiler.compile("package com.a \n " +
           "package b \n" +
           "trait Kammy ")
-        val loc = compiler.locations.result.find(_._1 == "Template").get._2
+        val loc = compiler.locations.result().find(_._1 == "Template").get._2
         loc.packageName shouldBe "com.a.b"
         loc.className shouldBe "Kammy"
         loc.topLevelClass shouldBe "Kammy"
@@ -149,7 +149,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for class constructor body" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.b \n class Tammy { val name = 'sam } ")
-        val loc = compiler.locations.result.find(_._1 == "ValDef").get._2
+        val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
         loc.packageName shouldBe "com.b"
         loc.className shouldBe "Tammy"
         loc.method shouldBe "<none>"
@@ -159,7 +159,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for object constructor body" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.b \n object Yammy { val name = 'sam } ")
-        val loc = compiler.locations.result.find(_._1 == "ValDef").get._2
+        val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
         loc.packageName shouldBe "com.b"
         loc.className shouldBe "Yammy"
         loc.topLevelClass shouldBe "Yammy"
@@ -170,7 +170,7 @@ class LocationTest extends FreeSpec with Matchers {
       "for trait constructor body" in {
         val compiler = ScoverageCompiler.locationCompiler
         compiler.compile("package com.b \n trait Wammy { val name = 'sam } ")
-        val loc = compiler.locations.result.find(_._1 == "ValDef").get._2
+        val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
         loc.packageName shouldBe "com.b"
         loc.className shouldBe "Wammy"
         loc.topLevelClass shouldBe "Wammy"
@@ -185,8 +185,8 @@ class LocationTest extends FreeSpec with Matchers {
         .compile(
           "package com.a; object A { def foo(b : B) : Unit = b.invoke }; trait B { def invoke : Unit }; class C { A.foo(new B { def invoke = () }) }")
       println()
-      println(compiler.locations.result.mkString("\n"))
-      val loc = compiler.locations.result.filter(_._1 == "Template").last._2
+      println(compiler.locations.result().mkString("\n"))
+      val loc = compiler.locations.result().filter(_._1 == "Template").last._2
       loc.packageName shouldBe "com.a"
       loc.className shouldBe "C"
       loc.topLevelClass shouldBe "C"
@@ -199,8 +199,8 @@ class LocationTest extends FreeSpec with Matchers {
       compiler.compile(
         "package com.a; object A { def foo(b : B) : Unit = b.invoke }; trait B { def invoke : Unit }; class C { A.foo(new B { def invoke = () }) }")
       println()
-      println(compiler.locations.result.mkString("\n"))
-      val loc = compiler.locations.result.filter(_._1 == "DefDef").last._2
+      println(compiler.locations.result().mkString("\n"))
+      val loc = compiler.locations.result().filter(_._1 == "DefDef").last._2
       loc.packageName shouldBe "com.a"
       loc.className shouldBe "C"
       loc.topLevelClass shouldBe "C"

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageXmlMergerTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageXmlMergerTest.scala
@@ -9,6 +9,8 @@ class ScoverageXmlMergerTest extends FreeSpec with Matchers {
   val node1 = scala.xml.XML.load(getClass.getResourceAsStream("/scoverage/report1.xml"))
   val node2 = scala.xml.XML.load(getClass.getResourceAsStream("/scoverage/report2.xml"))
 
+  private def formattedLocally(decimal: BigDecimal) = "%.2f".format(decimal)
+
   "scoverage xml merger" - {
     "should add top level statement-count" in {
       val node = ScoverageXmlMerger.merge(List(node1, node2))
@@ -20,7 +22,7 @@ class ScoverageXmlMergerTest extends FreeSpec with Matchers {
     }
     "should recalculate statement-rate" in {
       val node = ScoverageXmlMerger.merge(List(node1, node2))
-      (node \ "@statement-rate").text.toDouble shouldBe 91.67
+      (node \ "@statement-rate").text shouldBe formattedLocally(91.67)
     }
     "should reset timestamp" in {
       val node = ScoverageXmlMerger.merge(List(node1, node2))

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageXmlReaderTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageXmlReaderTest.scala
@@ -52,7 +52,7 @@ class ScoverageXmlReaderTest extends FreeSpec with Matchers {
       temp.deleteOnExit()
       new ScoverageXmlWriter(new File("/home/sam"), temp, false).write(coverage)
 
-      val actual = ScoverageXmlReader.read(IOUtils.reportFile(temp, false))
+      val actual = ScoverageXmlReader.read(IOUtils.reportFile(temp, debug = false))
       // we don't care about the statement ids as the will change on reading back in
       actual.statements.map(_.copy(id = 0)).toSet shouldEqual coverage.statements.map(_.copy(id = 0)).toSet
 

--- a/scalac-scoverage-runtime/src/test/scala/scoverage/InvokerMultiModuleTest.scala
+++ b/scalac-scoverage-runtime/src/test/scala/scoverage/InvokerMultiModuleTest.scala
@@ -16,7 +16,7 @@ class InvokerMultiModuleTest extends FunSuite with BeforeAndAfter {
     measurementDir.foreach(_.mkdirs)
   }
 
-  test("calling Invoker.invoked on with different directories puts mesurments in different directories") {
+  test("calling Invoker.invoked on with different directories puts measurements in different directories") {
 
     val testIds: Set[Int] = (1 to 10).toSet
 


### PR DESCRIPTION
Tests changed to use correct separator for floating numbers (one from current `Locale`).

Disclaimer required by the lawyers:

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.