### PR TITLE
Change test output to directory inside `target`

### DIFF
--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -22,6 +22,10 @@ object ScoverageCompiler {
     s.Yrangepos.value = true
     s.Yposdebug.value = true
     s.classpath.value = classPath.mkString(File.pathSeparator)
+
+    val path = s"./scalac-scoverage-plugin/target/scala-$ShortScalaVersion/test-generated-classes"
+    new File(path).mkdirs()
+    s.d.value = path
     s
   }
 


### PR DESCRIPTION
Files compiled by `ScoverageCompiler` during tests were put into '.',
polluting root directory with a lot of `.class` files. `clean` does not
remove them as they are not in `target`.

I moved them to
`scalac-scoverage-plugin/target/scala-$ShortScalaVersion/test-generated-classes`.