### PR TITLE
Output of invoker tests moved to target

### DIFF
--- a/scalac-scoverage-runtime/src/test/scala/scoverage/InvokerConcurrencyTest.scala
+++ b/scalac-scoverage-runtime/src/test/scala/scoverage/InvokerConcurrencyTest.scala
@@ -16,7 +16,7 @@ class InvokerConcurrencyTest extends FunSuite with BeforeAndAfter {
 
   implicit val executor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8))
 
-  val measurementDir = new File("invoker-test.measurement")
+  val measurementDir = new File("target/invoker-test.measurement")
 
   before {
     deleteMeasurementFiles()

--- a/scalac-scoverage-runtime/src/test/scala/scoverage/InvokerMultiModuleTest.scala
+++ b/scalac-scoverage-runtime/src/test/scala/scoverage/InvokerMultiModuleTest.scala
@@ -9,11 +9,13 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
  */
 class InvokerMultiModuleTest extends FunSuite with BeforeAndAfter {
 
-  val measurementDir = Array(new File("invoker-test.measurement0"), new File("invoker-test.measurement1"))
+  val measurementDir = Array(
+    new File("target/invoker-test.measurement0"),
+    new File("target/invoker-test.measurement1"))
 
   before {
     deleteMeasurementFiles()
-    measurementDir.foreach(_.mkdirs)
+    measurementDir.foreach(_.mkdirs())
   }
 
   test("calling Invoker.invoked on with different directories puts measurements in different directories") {


### PR DESCRIPTION
Similar as in previous PR - just moving temporary test artifacts to `target`.