### PR TITLE
Fixed that URL does not contain the "empty"

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -215,9 +215,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
       val path = fileRelativeToSource.getParent
       val value = fileRelativeToSource.getName
 
-      if (path.eq(null)) {
-        "(empty)/" + value
-      } else if (path.ne("")) {
+      if (path.ne("")) {
         // (Normalise the pathSeparator to "/" in case we are running on Windows)
         fileRelativeToSource.toString.replace(File.separator, "/")
       } else {

--- a/scalac-scoverage-plugin/src/test/resources/scoverage/forHtmlWriter/src/main/scala/Class1.scala
+++ b/scalac-scoverage-plugin/src/test/resources/scoverage/forHtmlWriter/src/main/scala/Class1.scala
@@ -1,0 +1,5 @@
+package coverage.sample
+
+class Class1 {
+  def msg_coverage = println("measure coverage of code")
+}

--- a/scalac-scoverage-plugin/src/test/resources/scoverage/forHtmlWriter/src/main/scala/subdir/Class2.scala
+++ b/scalac-scoverage-plugin/src/test/resources/scoverage/forHtmlWriter/src/main/scala/subdir/Class2.scala
@@ -1,0 +1,5 @@
+package coverage.sample
+
+class Class2 {
+  def msg_test = println("test code")
+}

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageHtmlWriterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageHtmlWriterTest.scala
@@ -1,0 +1,63 @@
+package scoverage
+
+import java.io._
+import java.util.UUID
+import scala.io.Source
+
+import scala.xml.XML
+
+import scoverage.report.ScoverageHtmlWriter
+
+import org.scalatest.FunSuite
+
+class ScoverageHtmlWriterTest extends FunSuite {
+
+  test("HTML coverage report has been created correctly") {
+
+    def tempDir(): File = {
+      val dir = new File(IOUtils.getTempDirectory, UUID.randomUUID().toString)
+      dir.mkdirs()
+      dir.deleteOnExit()
+      dir
+    }
+
+    val coverage = Coverage()
+
+    val class2 = getClass.getResource("forHtmlWriter/src/main/scala/subdir/Class2.scala").getFile()
+    val class1 = getClass.getResource("forHtmlWriter/src/main/scala/Class1.scala").getFile()
+
+    coverage.add(
+      Statement(class2,
+        Location("coverage.sample", "Class2","Class", ClassType.Object, "msg_test", class2),
+        2, 57, 77, 4, "scala.this.Predef.println(&quot;test code&quot;)",
+        "scala.Predef.println", "Apply", false, 0)
+    )
+
+    coverage.add(
+      Statement(class1,
+        Location("coverage.sample", "Class1","Class", ClassType.Object, "msg_coverage", class1),
+        1, 61, 96, 4, "scala.this.Predef.println(&quot;measure coverage of code&quot;)",
+        "scala.Predef.println", "Apply", false, 0)
+    )
+
+    val dir = getClass.getResource("forHtmlWriter/src/main/scala/").getFile()
+    val outputDir = tempDir()
+
+    val htmlWriter = new ScoverageHtmlWriter(new File(dir), outputDir)
+    htmlWriter.write(coverage)
+
+    val htmls = List("overview.html", "coverage.sample.html")
+
+    for (html <- htmls) {
+      val xml = XML.loadString(Source.fromFile(new File(outputDir, html)).getLines.mkString)
+      val links = for (node <- xml \\ "a") yield {
+        node.attribute("href") match {
+          case Some(url) => url.toString
+          case None => fail()
+        }
+      }
+   
+      assert( links.toSet == Set("Class1.scala.html", "subdir/Class2.scala.html") )
+    }
+  }
+}


### PR DESCRIPTION
When we generate a coverage report of source code that is placed directly below `'src/main/scala/'` , the link to the report of HTML, 'empty' string is inserted that, it is not even properly reaction click.

Example:

    source -> src/main/scala/Version.scala
    URL in index.html -> file:///Users/xxxx/dev/xxxx/target/scala-2.11/scoverage-report/(empty)/Version.scala.html
    Generated HTML -> /Users/xxxx/dev/scala/xxxx/target/scala-2.11/scoverage-report/Version.scala.html