### PR TITLE
Use SBT Release Plugin (https://github.com/sbt/sbt-release). 

### DIFF
--- a/project/Scoverage.scala
+++ b/project/Scoverage.scala
@@ -1,10 +1,12 @@
 import sbt.Keys._
 import sbt._
+import sbtrelease.ReleasePlugin
+import sbtrelease.ReleasePlugin.ReleaseKeys
+import com.typesafe.sbt.pgp.PgpKeys
 
 object Scoverage extends Build {
 
   val Org = "org.scoverage"
-  val Version = "1.0.5-SNAPSHOT"
   val Scala = "2.11.4"
   val MockitoVersion = "1.9.5"
   val ScalatestVersion = "2.2.2"
@@ -12,7 +14,6 @@ object Scoverage extends Build {
   lazy val LocalTest = config("local") extend Test
 
   val appSettings = Seq(
-    version := Version,
     organization := Org,
     scalaVersion := Scala,
     crossScalaVersions := Seq("2.10.4", "2.11.4"),
@@ -60,6 +61,9 @@ object Scoverage extends Build {
     pomIncludeRepository := {
       _ => false
     }
+  ) ++ ReleasePlugin.releaseSettings ++ Seq(
+    ReleaseKeys.crossBuild := true,
+    ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value
   )
 
   lazy val root = Project("scalac-scoverage", file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.3.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.0.5-SNAPSHOT"


### PR DESCRIPTION
Next proposal related to https://github.com/scoverage/scalac-scoverage-plugin/issues/85

Use SBT Release Plugin (https://github.com/sbt/sbt-release) instead of manual release process.
To release next version of SCoverage just run "sbt release" (not "sbt +release"!!!).
