### PR TITLE
Enable sorting in HTML report 

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -17,8 +17,8 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
 
     val index = IOUtils.readStreamAsString(getClass.getResourceAsStream("/scoverage/index.html"))
     IOUtils.writeToFile(indexFile, index)
-    IOUtils.writeToFile(packageFile, packageList(coverage).toString)
-    IOUtils.writeToFile(overviewFile, overview(coverage).toString)
+    IOUtils.writeToFile(packageFile, packageList(coverage).toString())
+    IOUtils.writeToFile(overviewFile, overview(coverage).toString())
 
     coverage.packages.foreach(writePackage)
   }
@@ -31,7 +31,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
     // to com.example.html
     val file = new File(outputDir, packageOverviewRelativePath(pkg))
     file.getParentFile.mkdirs()
-    IOUtils.writeToFile(file, packageOverview(pkg).toString)
+    IOUtils.writeToFile(file, packageOverview(pkg).toString())
     pkg.files.foreach(writeFile)
   }
 
@@ -39,7 +39,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
     // each highlighted file is written out using the same structure as the original file.
     val file = new File(outputDir, relativeSource(mfile.source) + ".html")
     file.getParentFile.mkdirs()
-    IOUtils.writeToFile(file, filePage(mfile).toString)
+    IOUtils.writeToFile(file, filePage(mfile).toString())
   }
 
   private def packageOverviewRelativePath(pkg: MeasuredPackage) = pkg.name.replace("<empty>", "(empty)") + ".html"

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -57,10 +57,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
         <title id='title'>
           {filename}
         </title>
-        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css"/>
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-        <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.18.3/addons/pager/jquery.tablesorter.pager.min.js"></script>
+        {plugins}
         <style>
           {css}
         </style>
@@ -135,21 +132,13 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
                 |	overflow: hidden;
                 |}""".stripMargin
 
-    val tableScript = """$(document).ready(function() {$("#packages").tablesorter();});"""
-
     <head>
       <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
       <title id='title'>Scoverage Code Coverage</title>
-      <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css"/>
-      <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-      <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
-      <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.18.3/addons/pager/jquery.tablesorter.pager.min.js"></script>
+      {plugins}
       <style>
         {css}
       </style>
-      <script>
-        {tableScript}
-      </script>
     </head>
   }
 
@@ -282,10 +271,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
         <title id='title'>
           Scoverage Code Coverage
         </title>
-        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css"/>
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-        <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.18.3/addons/pager/jquery.tablesorter.pager.min.js"></script>
+        {plugins}
       </head>
       <body style="font-family: monospace;">
         <table class="table table-striped" style="font-size: 13px">
@@ -314,7 +300,7 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
   }
 
   def risks(coverage: Coverage, limit: Int) = {
-    <table id="packages" class="table table-striped" style="font-size: 12px">
+    <table class="tablesorter table table-striped" style="font-size: 12px">
       <thead>
         <tr>
           <th>
@@ -534,6 +520,17 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
         </td>
       </tr>
     </table>
+  }
+  
+  def plugins = {
+      <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.20.1/css/theme.default.min.css" type="text/css"/>
+      <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.20.1/js/jquery.tablesorter.min.js"></script>
+      <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" type="text/css"/>
+      <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+      <script type="text/javascript">
+        {xml.Unparsed("""$(document).ready(function() {$(".tablesorter").tablesorter();});""")}
+      </script>
   }
 }
 

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -274,23 +274,22 @@ class ScoverageHtmlWriter(sourceDirectory: File, outputDir: File) {
         {plugins}
       </head>
       <body style="font-family: monospace;">
-        <table class="table table-striped" style="font-size: 13px">
+        <table class="tablesorter table table-striped" style="font-size: 13px">
+          <thead>
+            <tr>
+              <td>
+                <a href="overview.html" target="mainFrame">All packages</a>
+              </td>
+              <td>{coverage.statementCoverageFormatted}%</td>
+            </tr>
+          </thead>
           <tbody>
+            {coverage.packages.map(arg =>
             <tr>
               <td>
-                <a href="overview.html" target="mainFrame">
-                  All packages
-                </a>{coverage.statementCoverageFormatted}
-                %
+                <a href={packageOverviewRelativePath(arg)} target="mainFrame">{arg.name}</a>
               </td>
-            </tr>{coverage.packages.map(arg =>
-            <tr>
-              <td>
-                <a href={packageOverviewRelativePath(arg)} target="mainFrame">
-                  {arg.name}
-                </a>{arg.statementCoverageFormatted}
-                %
-              </td>
+              <td>{arg.statementCoverageFormatted}%</td>
             </tr>
           )}
           </tbody>


### PR DESCRIPTION
The current HTML report contains partial references to the jquery tablesorter plugin.

This PR enables sorting of the classes and packages tables, but does not enable filtering or pagination.

I'm not sure if it's a good idea to move the package coverage levels into their own column, but I think this is required for sensible sorting. Comments welcome.

Thanks,
Stu