### PR TITLE
Don't create unused temporary file on every plugin initialization

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
@@ -47,7 +47,7 @@ class ScoveragePlugin(val global: Global) extends Plugin {
 class ScoverageOptions {
   var excludedPackages: Seq[String] = Nil
   var excludedFiles: Seq[String] = Nil
-  var dataDir: String = File.createTempFile("scoverage_datadir_not_defined", ".tmp").getParent
+  var dataDir: String = IOUtils.getTempPath
 }
 
 class ScoverageInstrumentationComponent(val global: Global)


### PR DESCRIPTION
`ScoverageOptions.dataDir` parameter is initialized with value `File.createTempFile("scoverage_datadir_not_defined", ".tmp").getParent`.

Setting `dataDir` is required in Scalac plugin parameters (`-P:scoverage:dataDir:<pathtodatadir>`), if not set exception will be thrown, so ANY initial value is OK because it will be overwritten anyway. Using `File.createTempFile` to initialize causes temporary `scoverage_datadir_not_defined<random_hash>.tmp` file creation as a side effect (this file will never be used) so it's not the best choice.