### PR TITLE
https://github.com/scoverage/scalac-scoverage-plugin/pull/109 introduced...

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/IOUtils.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/IOUtils.scala
@@ -82,23 +82,4 @@ object IOUtils {
     acc
   }
 
-  /**
-   * Converts absolute path to relative one if any of the source directories is it's parent.
-   * If there is no parent directory, the path is returned unchanged (absolute).
-   * 
-   * @param src absolute file path in canonical form
-   * @param sourcePaths absolute source paths in canonical form WITH trailing file separators
-   */
-  def relativeSource(src: String, sourcePaths: Seq[String]): String = {
-    val sourceRoot: Option[String] = sourcePaths.find(
-      sourcePath => src.startsWith(sourcePath)
-    )
-    sourceRoot match {
-      case Some(path: String) => src.replace(path, "")
-      case _ =>
-        val fmtSourcePaths: String = sourcePaths.mkString("'", "', '", "'")
-        throw new RuntimeException(s"No source root found for '$src' (source roots: $fmtSourcePaths)");
-    }
-  }
-
 }

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
@@ -1,0 +1,30 @@
+package scoverage.report
+
+import java.io.File
+
+class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File) {
+
+  // Source paths in canonical form WITH trailing file separator
+  private val formattedSourcePaths: Seq[String] = sourceDirectories filter ( _.isDirectory ) map ( _.getCanonicalPath + File.separator )
+
+  /**
+   * Converts absolute path to relative one if any of the source directories is it's parent.
+   * If there is no parent directory, the path is returned unchanged (absolute).
+   * 
+   * @param src absolute file path in canonical form
+   */
+  def relativeSource(src: String): String = relativeSource(src, formattedSourcePaths)
+
+  private def relativeSource(src: String, sourcePaths: Seq[String]): String = {
+    val sourceRoot: Option[String] = sourcePaths.find(
+      sourcePath => src.startsWith(sourcePath)
+    )
+    sourceRoot match {
+      case Some(path: String) => src.replace(path, "")
+      case _ =>
+        val fmtSourcePaths: String = sourcePaths.mkString("'", "', '", "'")
+        throw new RuntimeException(s"No source root found for '$src' (source roots: $fmtSourcePaths)");
+    }
+  }
+
+}

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
@@ -7,14 +7,11 @@ import scoverage._
 import scala.xml.{Node, PrettyPrinter}
 
 /** @author Stephen Samuel */
-class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) {
+class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends BaseReportWriter(sourceDirectories, outputDir) {
 
   def this (baseDir: File, outputDir: File) {
     this(Seq(baseDir), outputDir);
   }
-
-  // Source paths in canonical form WITH trailing file separator
-  val formattedSourcePaths: Seq[String] = sourceDirectories filter ( _.isDirectory ) map ( _.getCanonicalPath + File.separator )
   
   def format(double: Double): String = "%.2f".format(double)
 
@@ -94,7 +91,5 @@ class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) {
       </packages>
     </coverage>
   }
-
-  private def relativeSource(src: String): String = IOUtils.relativeSource(src, formattedSourcePaths)
 
 }

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -8,14 +8,11 @@ import scoverage._
 import scala.xml.Node
 
 /** @author Stephen Samuel */
-class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File) {
+class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File) extends BaseReportWriter(sourceDirectories, outputDir) {
 
   def this (sourceDirectory: File, outputDir: File) {
     this(Seq(sourceDirectory), outputDir);
   }
-
-  // Source paths in canonical form WITH trailing file separator
-  val formattedSourcePaths: Seq[String] = sourceDirectories filter ( _.isDirectory ) map ( _.getCanonicalPath + File.separator )
   
   def write(coverage: Coverage): Unit = {
     val indexFile = new File(outputDir.getAbsolutePath + "/index.html")
@@ -537,7 +534,4 @@ class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File) {
       </script>
   }
 
-  private def relativeSource(src: String): String = IOUtils.relativeSource(src, formattedSourcePaths)
-
 }
-

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlWriter.scala
@@ -2,20 +2,17 @@ package scoverage.report
 
 import java.io.File
 
-import _root_.scoverage._
+import scoverage._
 
 import scala.xml.{Node, PrettyPrinter}
 
 /** @author Stephen Samuel */
-class ScoverageXmlWriter(sourceDirectories: Seq[File], outputDir: File, debug: Boolean) {
+class ScoverageXmlWriter(sourceDirectories: Seq[File], outputDir: File, debug: Boolean) extends BaseReportWriter(sourceDirectories, outputDir) {
 
   def this (sourceDir: File, outputDir: File, debug: Boolean) {
     this(Seq(sourceDir), outputDir, debug);
   }
 
-  // Source paths in canonical form WITH trailing file separator
-  val formattedSourcePaths: Seq[String] = sourceDirectories filter ( _.isDirectory ) map ( _.getCanonicalPath + File.separator )
-  
   def write(coverage: Coverage): Unit = {
     val file = IOUtils.reportFile(outputDir, debug)
     IOUtils.writeToFile(file, new PrettyPrinter(120, 4).format(xml(coverage)))
@@ -103,7 +100,4 @@ class ScoverageXmlWriter(sourceDirectories: Seq[File], outputDir: File, debug: B
     </package>
   }
 
-  private def relativeSource(src: String): String = IOUtils.relativeSource(src, formattedSourcePaths)
-
 }
-


### PR DESCRIPTION
... code redundance in report writer classes. Base class created and common code moved there. "IOUtils.relativeSource" moved there too, because it's reports specific and works on paths as strings, not real files.

@sksamuel are you OK with this?