### PR TITLE
Change to HTTPS links of outside resources on html report

### DIFF
--- a/scalac-scoverage-plugin/src/main/resources/scoverage/index.html
+++ b/scalac-scoverage-plugin/src/main/resources/scoverage/index.html
@@ -2,7 +2,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title id='title'>Scoverage Code Coverage</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.3.0/pure-min.css">
 </head>
 <frameset cols="25%,*">
     <frame src="packages.html" name="packagesFrame">

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -538,11 +538,11 @@ class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File) extends
   }
   
   def plugins = {
-      <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.20.1/css/theme.default.min.css" type="text/css"/>
-      <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.20.1/js/jquery.tablesorter.min.js"></script>
-      <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" type="text/css"/>
-      <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.20.1/js/jquery.tablesorter.min.js"></script>
+      <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" type="text/css"/>
+      <script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
       <script type="text/javascript">
         {xml.Unparsed("""$(document).ready(function() {$(".tablesorter").tablesorter();});""")}
       </script>


### PR DESCRIPTION
We should use HTTPS.

`yui.yahooapis.com` isn't accepting HTTPS request. So I changed link to cdnjs and checked both resources are same.

```
$ curl -s http://yui.yahooapis.com/pure/0.3.0/pure-min.css | md5sum; curl -s https://cdnjs.cloudflare.com/ajax/libs/pure/0.3.0/pure-min.css | md5sum
ecb2a387c291b6f85ebada1054f33e09  -
ecb2a387c291b6f85ebada1054f33e09  -
```