### PR TITLE
Move to github dtd from sourceforge

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
@@ -17,7 +17,7 @@ class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends 
 
   def write(coverage: Coverage): Unit = {
     val file = new File(outputDir, "cobertura.xml")
-    IOUtils.writeToFile(file, "<?xml version=\"1.0\"?>\n<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n" + 
+    IOUtils.writeToFile(file, "<?xml version=\"1.0\"?>\n<!DOCTYPE coverage SYSTEM \"https://raw.githubusercontent.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd\">\n" + 
         new PrettyPrinter(120, 4).format(xml(coverage)))
   }
 

--- a/scalac-scoverage-plugin/src/test/resources/scoverage/cobertura.sample.xml
+++ b/scalac-scoverage-plugin/src/test/resources/scoverage/cobertura.sample.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!--DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-03.dtd"-->
+<!--DOCTYPE coverage SYSTEM "https://raw.githubusercontent.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-04.dtd"-->
 
 <coverage line-rate="0.9" branch-rate="0.75" version="1.9" timestamp="1187350905008">
     <sources>


### PR DESCRIPTION
@sksamuel This fixes the sourceforge dtd problem, but means you will have to release a version of this and the sbt-scoverage plugin.
