### PR TITLE
Fix typos on report index

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -444,7 +444,7 @@ class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File) extends
       </tr>
       <tr>
         <td>
-          Lines per file
+          Lines per file:
         </td>
         <td>
           {coverage.linesPerFileFormatted}
@@ -456,7 +456,7 @@ class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File) extends
           {coverage.packageCount.toString}
         </td>
         <td>
-          Clases per package:
+          Classes per package:
         </td>
         <td>
           {coverage.avgClassesPerPackageFormatted}


### PR DESCRIPTION
Fixed a spelling error and added a missing colon.