### PR TITLE
Fix pure-min.css URL

### DIFF
--- a/scalac-scoverage-plugin/src/main/resources/scoverage/index.html
+++ b/scalac-scoverage-plugin/src/main/resources/scoverage/index.html
@@ -2,7 +2,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title id='title'>Scoverage Code Coverage</title>
-    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.3.0/pure-min.css">
 </head>
 <frameset cols="25%,*">
     <frame src="packages.html" name="packagesFrame">


### PR DESCRIPTION
(Based on https://github.com/scoverage/scalac-scoverage-plugin/pull/124 but with resolved merge conflict)

the https version of pure-min.css from yui.yahooapis.com has a 404 error, replacing it with cloudflare cdn