### PR TITLE
CoverageAggregator refuses to aggregate single file

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
@@ -13,7 +13,7 @@ object CoverageAggregator {
 
   def aggregate(files: Seq[File], clean: Boolean): Option[Coverage] = {
     println(s"[info] Found ${files.size} subproject report files [${files.mkString(",")}]")
-    if (files.size > 1) {
+    if (files.size > 0) {
       val coverage = aggregatedCoverage(files)
       if (clean) files foreach (_.delete)
       Some(coverage)


### PR DESCRIPTION
If only one scoverage.xml file is found, the aggregator refuses to produce output:

```
[info] Found 1 subproject report files [/Users/arkadiy/mine/L-SPACE/l_space/target/scala-2.11/scoverage-report/scoverage.xml]
[info] No subproject data to aggregate, skipping reports
```

This allows aggregation of a single file

Fixes #144