### PR TITLE
Print Doubles with two fraction digits using US locale

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/DoubleFormat.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/DoubleFormat.scala
@@ -1,0 +1,19 @@
+package scoverage
+
+import java.text.{DecimalFormat, DecimalFormatSymbols}
+import java.util.Locale
+
+object DoubleFormat {
+  private[this] val twoFractionDigitsFormat: DecimalFormat = {
+    val fmt = new DecimalFormat()
+    fmt.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US))
+    fmt.setMinimumIntegerDigits(1)
+    fmt.setMinimumFractionDigits(2)
+    fmt.setMaximumFractionDigits(2)
+    fmt.setGroupingUsed(false)
+    fmt
+  }
+
+  def twoFractionDigits(d: Double) = twoFractionDigitsFormat.format(d)
+
+}

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/coverage.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/coverage.scala
@@ -2,6 +2,8 @@ package scoverage
 
 import java.io.File
 
+import scoverage.DoubleFormat.twoFractionDigits
+
 import scala.collection.mutable
 
 /**
@@ -24,14 +26,14 @@ case class Coverage()
 
 
   def avgClassesPerPackage = classCount / packageCount.toDouble
-  def avgClassesPerPackageFormatted: String = "%.2f".format(avgClassesPerPackage)
+  def avgClassesPerPackageFormatted: String = twoFractionDigits(avgClassesPerPackage)
 
   def avgMethodsPerClass = methodCount / classCount.toDouble
-  def avgMethodsPerClassFormatted: String = "%.2f".format(avgMethodsPerClass)
+  def avgMethodsPerClassFormatted: String = twoFractionDigits(avgMethodsPerClass)
 
   def loc = files.map(_.loc).sum
   def linesPerFile = loc / fileCount.toDouble
-  def linesPerFileFormatted: String = "%.2f".format(linesPerFile)
+  def linesPerFileFormatted: String = twoFractionDigits(linesPerFile)
 
   // returns the classes by least coverage
   def risks(limit: Int) = classes.toSeq.sortBy(_.statementCount).reverse.sortBy(_.statementCoverage).take(limit)
@@ -158,7 +160,7 @@ trait CoverageMetrics {
   def invokedStatementCount = invokedStatements.size
   def statementCoverage: Double = if (statementCount == 0) 1 else invokedStatementCount / statementCount.toDouble
   def statementCoveragePercent = statementCoverage * 100
-  def statementCoverageFormatted: String = "%.2f".format(statementCoveragePercent)
+  def statementCoverageFormatted: String = twoFractionDigits(statementCoveragePercent)
   def branches: Iterable[Statement] = statements.filter(_.branch)
   def branchCount: Int = branches.size
   def branchCoveragePercent = branchCoverage * 100
@@ -179,7 +181,7 @@ trait CoverageMetrics {
       invokedBranchesCount / branchCount.toDouble
     }
   }
-  def branchCoverageFormatted: String = "%.2f".format(branchCoveragePercent)
+  def branchCoverageFormatted: String = twoFractionDigits(branchCoveragePercent)
 }
 
 trait ClassCoverage {

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
@@ -2,6 +2,7 @@ package scoverage.report
 
 import java.io.File
 
+import scoverage.DoubleFormat.twoFractionDigits
 import scoverage._
 
 import scala.xml.{Node, PrettyPrinter}
@@ -13,8 +14,6 @@ class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends 
     this(Seq(baseDir), outputDir)
   }
 
-  def format(double: Double): String = "%.2f".format(double)
-
   def write(coverage: Coverage): Unit = {
     val file = new File(outputDir, "cobertura.xml")
     IOUtils.writeToFile(file, "<?xml version=\"1.0\"?>\n<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n" +
@@ -24,8 +23,8 @@ class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends 
   def method(method: MeasuredMethod): Node = {
     <method name={method.name}
             signature="()V"
-            line-rate={format(method.statementCoverage)}
-            branch-rate={format(method.branchCoverage)}>
+            line-rate={twoFractionDigits(method.statementCoverage)}
+            branch-rate={twoFractionDigits(method.branchCoverage)}>
       <lines>
         {method.statements.map(stmt =>
           <line
@@ -40,8 +39,8 @@ class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends 
   def klass(klass: MeasuredClass): Node = {
     <class name={klass.fullClassName}
            filename={relativeSource(klass.source).replace(File.separator, "/")}
-           line-rate={format(klass.statementCoverage)}
-           branch-rate={format(klass.branchCoverage)}
+           line-rate={twoFractionDigits(klass.statementCoverage)}
+           branch-rate={twoFractionDigits(klass.branchCoverage)}
            complexity="0">
       <methods>
         {klass.methods.map(method)}
@@ -59,8 +58,8 @@ class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends 
 
   def pack(pack: MeasuredPackage): Node = {
     <package name={pack.name}
-             line-rate={format(pack.statementCoverage)}
-             branch-rate={format(pack.branchCoverage)}
+             line-rate={twoFractionDigits(pack.statementCoverage)}
+             branch-rate={twoFractionDigits(pack.branchCoverage)}
              complexity="0">
       <classes>
         {pack.classes.map(klass)}
@@ -73,12 +72,12 @@ class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends 
   }
 
   def xml(coverage: Coverage): Node = {
-    <coverage line-rate={format(coverage.statementCoverage)}
+    <coverage line-rate={twoFractionDigits(coverage.statementCoverage)}
               lines-valid={coverage.statementCount.toString}
               lines-covered={coverage.invokedStatementCount.toString}
               branches-valid={coverage.branchCount.toString}
               branches-covered={coverage.invokedBranchesCount.toString}
-              branch-rate={format(coverage.branchCoverage)}
+              branch-rate={twoFractionDigits(coverage.branchCoverage)}
               complexity="0"
               version="1.0"
               timestamp={System.currentTimeMillis.toString}>

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlMerger.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlMerger.scala
@@ -1,5 +1,7 @@
 package scoverage.report
 
+import scoverage.DoubleFormat.twoFractionDigits
+
 import scala.xml.Node
 
 /** @author Stephen Samuel */
@@ -12,7 +14,7 @@ object ScoverageXmlMerger {
     def merge(node1: Node, node2: Node): Node = {
       val statementCount = (node1 \ "@statement-count").text.toInt + (node2 \ "@statement-count").text.toInt
       val statementsInvoked = (node1 \ "@statements-invoked").text.toInt + (node2 \ "@statements-invoked").text.toInt
-      val statementRate = "%.2f".format(statementsInvoked.toDouble / statementCount.toDouble * 100.0d)
+      val statementRate = twoFractionDigits(statementsInvoked.toDouble / statementCount.toDouble * 100.0d)
       val packages = (node1 \\ "packages") ++ (node2 \\ "packages")
       <scoverage statement-count={statementCount.toString}
                  statements-invoked={statementsInvoked.toString}

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
@@ -1,7 +1,7 @@
 package scoverage
 
 import java.io.File
-import java.util.{Locale, UUID}
+import java.util.UUID
 import javax.xml.parsers.DocumentBuilderFactory
 
 import org.scalatest.{BeforeAndAfter, FunSuite, OneInstancePerTest}
@@ -101,10 +101,8 @@ class CoberturaXmlWriterTest extends FunSuite with BeforeAndAfter with OneInstan
 
     val xml = XML.loadFile(fileIn(dir))
 
-    def formattedLocally(decimal: BigDecimal) = "%.2f".format(decimal)
-
-    assert(xml \\ "coverage" \@ "line-rate" === formattedLocally(0.33), "line-rate")
-    assert(xml \\ "coverage" \@ "branch-rate" === formattedLocally(0.50), "branch-rate")
+    assert(xml \\ "coverage" \@ "line-rate" === "0.33", "line-rate")
+    assert(xml \\ "coverage" \@ "branch-rate" === "0.50", "branch-rate")
 
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageXmlMergerTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageXmlMergerTest.scala
@@ -9,8 +9,6 @@ class ScoverageXmlMergerTest extends FreeSpec with Matchers {
   val node1 = scala.xml.XML.load(getClass.getResourceAsStream("/scoverage/report1.xml"))
   val node2 = scala.xml.XML.load(getClass.getResourceAsStream("/scoverage/report2.xml"))
 
-  private def formattedLocally(decimal: BigDecimal) = "%.2f".format(decimal)
-
   "scoverage xml merger" - {
     "should add top level statement-count" in {
       val node = ScoverageXmlMerger.merge(List(node1, node2))
@@ -22,7 +20,7 @@ class ScoverageXmlMergerTest extends FreeSpec with Matchers {
     }
     "should recalculate statement-rate" in {
       val node = ScoverageXmlMerger.merge(List(node1, node2))
-      (node \ "@statement-rate").text shouldBe formattedLocally(91.67)
+      (node \ "@statement-rate").text.toDouble shouldBe 91.67
     }
     "should reset timestamp" in {
       val node = ScoverageXmlMerger.merge(List(node1, node2))


### PR DESCRIPTION
In some locales (eg. polish), doubles are printed with , as decimal separator:

`<scoverage
statement-count="1250" statements-invoked="213" statement-rate="17,04" branch-rate="17,91" version="1.0" timestamp="1458599746821">`

Which is not correct as it breaks all code relying on `.toDouble` in scala.