### PR TITLE
Resolve canonical path for src in BaseReportWriter.relativeSource

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.3.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
@@ -10,20 +10,22 @@ class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File) {
   /**
    * Converts absolute path to relative one if any of the source directories is it's parent.
    * If there is no parent directory, the path is returned unchanged (absolute).
-   * 
+   *
    * @param src absolute file path in canonical form
    */
   def relativeSource(src: String): String = relativeSource(src, formattedSourcePaths)
 
   private def relativeSource(src: String, sourcePaths: Seq[String]): String = {
+    // We need the canonical path for the given src because our formattedSourcePaths are canonical
+    val canonicalSrc = new File(src).getCanonicalPath
     val sourceRoot: Option[String] = sourcePaths.find(
-      sourcePath => src.startsWith(sourcePath)
+      sourcePath => canonicalSrc.startsWith(sourcePath)
     )
     sourceRoot match {
-      case Some(path: String) => src.replace(path, "")
+      case Some(path: String) => canonicalSrc.replace(path, "")
       case _ =>
         val fmtSourcePaths: String = sourcePaths.mkString("'", "', '", "'")
-        throw new RuntimeException(s"No source root found for '$src' (source roots: $fmtSourcePaths)");
+        throw new RuntimeException(s"No source root found for '$canonicalSrc' (source roots: $fmtSourcePaths)");
     }
   }
 


### PR DESCRIPTION
We need the canonical path for the given `src` because our `formattedSourcePaths` are canonical.

The sources we iniitally store are non-canonical, provided directly through SBT's settings keys, which could refer to things like simlinks and '.' or '..' characters. This causes problems when trying to resolve sources because we try to match against [**canonical** `formattedSourcePaths`](https://github.com/lloydmeta/scalac-scoverage-plugin/blob/0acc293b5954902ab4e86ae9ba1540af40876125/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala#L8).

The use case is when you have `unmanagedSourceDirectories` in projects that have non-standard base directories, such as in @lihaoyi's [sourcecode](https://github.com/lihaoyi/sourcecode/blob/master/build.sbt#L21-L239).  Before this fix, trying to run coverage reports would cause `java.lang.RuntimeException: No source root found` errors.

Misc other changes:

- Bump SBT version
- Bump PGP plugin version