### PR TITLE
Added the ability to disable coverage data recording at run-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ To see scoverage in action check out the [samples](https://github.com/scoverage/
 
 ### Release History
 
+* Added the ability to disable coverage data recording by setting the JVM property `scoverage.recording.enabled` to `false`
+* Slight optimization of runtime
+
 ##### 26th April 2015 1.1.0
 
 * Bug fixes


### PR DESCRIPTION
Added the ability to disable coverage data recording by setting the JVM property `scoverage.recording.enabled` to `false` (needed to run the instrumented code on
other machines such as docker containers).

Slight optimization of runtime
