### PR TITLE
Configurable extra runsBefore and runsAfter phases

### DIFF
--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -75,7 +75,7 @@ class ScoverageCompiler(settings: scala.tools.nsc.Settings, reporter: scala.tool
       .getAbsolutePath
   }
 
-  val instrumentationComponent = new ScoverageInstrumentationComponent(this)
+  val instrumentationComponent = new ScoverageInstrumentationComponent(this, None, None)
   instrumentationComponent.setOptions(new ScoverageOptions())
   val testStore = new ScoverageTestStoreComponent(this)
   val validator = new PositionValidator(this)


### PR DESCRIPTION
Relevant issue: https://github.com/scoverage/scalac-scoverage-plugin/issues/163

Currently scalac-scoverage-plugin runs after `typer` and before `patmat` phases. There are no other phases in between so the order is unique and fixed.

Situation changes when using other scalac plugins which add phases in between typer and patmat. Scoverage phase can be then nondeterministically inserted somewhere between these new phases.

To fine-tune phases ordering I propose adding following flags
```
-P:scoverage:extraAfterPhase:<phaseName>
-P:scoverage:extraBeforePhase:<phaseName>
```
which would specify what other phases beside typer and patmat need to taken into account when determining phase ordering by appending them to `runsAfter` and `runsBefore` lists.
