### PR TITLE
Filter out statements not in source roots

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
@@ -2,7 +2,9 @@ package scoverage.report
 
 import java.io.File
 
-class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File) {
+import scoverage.Coverage
+
+class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File, ignoreStatementsNotInSrcDirs: Boolean) {
 
   // Source paths in canonical form WITH trailing file separator
   private val formattedSourcePaths: Seq[String] = sourceDirectories filter ( _.isDirectory ) map ( _.getCanonicalPath + File.separator )
@@ -10,7 +12,7 @@ class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File) {
   /**
    * Converts absolute path to relative one if any of the source directories is it's parent.
    * If there is no parent directory, the path is returned unchanged (absolute).
-   * 
+   *
    * @param src absolute file path in canonical form
    */
   def relativeSource(src: String): String = relativeSource(src, formattedSourcePaths)
@@ -25,6 +27,34 @@ class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File) {
         val fmtSourcePaths: String = sourcePaths.mkString("'", "', '", "'")
         throw new RuntimeException(s"No source root found for '$src' (source roots: $fmtSourcePaths)");
     }
+  }
+
+  def preprocessCoverage(coverage: Coverage): Coverage = {
+    if (ignoreStatementsNotInSrcDirs)
+      filteredCoverage(coverage)
+    else
+      coverage
+  }
+
+  /**
+    * Filters out statements not in source roots
+    * @return new Coverage instance with statements whose src paths are in root source paths.
+    */
+  private def filteredCoverage(coverage: Coverage): Coverage = {
+    val filteredCoverage = Coverage()
+    coverage.statements.foreach { stmt =>
+      if (isInSourceRoots(stmt.source))
+        filteredCoverage.add(stmt)
+    }
+    coverage.ignoredStatements.foreach { stmt =>
+      if (isInSourceRoots(stmt.source))
+        filteredCoverage.addIgnoredStatement(stmt)
+    }
+    filteredCoverage
+  }
+
+  private def isInSourceRoots(src: String): Boolean = {
+    formattedSourcePaths.exists(sourcePath => src.startsWith(sourcePath))
   }
 
 }

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
@@ -8,16 +8,17 @@ import scoverage._
 import scala.xml.{Node, PrettyPrinter}
 
 /** @author Stephen Samuel */
-class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends BaseReportWriter(sourceDirectories, outputDir) {
+class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File, ignoreStatementsNotInSrcDirs: Boolean)
+  extends BaseReportWriter(sourceDirectories, outputDir, ignoreStatementsNotInSrcDirs) {
 
-  def this (baseDir: File, outputDir: File) {
-    this(Seq(baseDir), outputDir)
+  def this (baseDir: File, outputDir: File, ignoreStatementsNotInSrcDirs: Boolean = false) {
+    this(Seq(baseDir), outputDir, ignoreStatementsNotInSrcDirs)
   }
 
   def write(coverage: Coverage): Unit = {
     val file = new File(outputDir, "cobertura.xml")
     IOUtils.writeToFile(file, "<?xml version=\"1.0\"?>\n<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n" +
-        new PrettyPrinter(120, 4).format(xml(coverage)))
+        new PrettyPrinter(120, 4).format(xml(preprocessCoverage(coverage))))
   }
 
   def method(method: MeasuredMethod): Node = {

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -8,11 +8,12 @@ import scoverage._
 import scala.xml.Node
 
 /** @author Stephen Samuel */
-class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File, sourceEncoding: Option[String]) extends BaseReportWriter(sourceDirectories, outputDir) {
+class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File, sourceEncoding: Option[String], ignoreStatementsNotInSrcDirs: Boolean)
+  extends BaseReportWriter(sourceDirectories, outputDir, ignoreStatementsNotInSrcDirs) {
 
   // for backward compatibility only
-  def this (sourceDirectories: Seq[File], outputDir: File) {
-    this(sourceDirectories, outputDir, None);
+  def this (sourceDirectories: Seq[File], outputDir: File, ignoreStatementsNotInSrcDirs: Boolean = false) {
+    this(sourceDirectories, outputDir, None, ignoreStatementsNotInSrcDirs)
   }
   
   // for backward compatibility only
@@ -21,16 +22,18 @@ class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File, sourceE
   }
   
   def write(coverage: Coverage): Unit = {
+    val preprocessedCoverage = preprocessCoverage(coverage)
+
     val indexFile = new File(outputDir.getAbsolutePath + "/index.html")
     val packageFile = new File(outputDir.getAbsolutePath + "/packages.html")
     val overviewFile = new File(outputDir.getAbsolutePath + "/overview.html")
 
     val index = IOUtils.readStreamAsString(getClass.getResourceAsStream("/scoverage/index.html"))
     IOUtils.writeToFile(indexFile, index)
-    IOUtils.writeToFile(packageFile, packageList(coverage).toString())
-    IOUtils.writeToFile(overviewFile, overview(coverage).toString())
+    IOUtils.writeToFile(packageFile, packageList(preprocessedCoverage).toString())
+    IOUtils.writeToFile(overviewFile, overview(preprocessedCoverage).toString())
 
-    coverage.packages.foreach(writePackage)
+    preprocessedCoverage.packages.foreach(writePackage)
   }
 
   private def writePackage(pkg: MeasuredPackage): Unit = {

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlWriter.scala
@@ -7,15 +7,16 @@ import scoverage._
 import scala.xml.{Node, PrettyPrinter}
 
 /** @author Stephen Samuel */
-class ScoverageXmlWriter(sourceDirectories: Seq[File], outputDir: File, debug: Boolean) extends BaseReportWriter(sourceDirectories, outputDir) {
+class ScoverageXmlWriter(sourceDirectories: Seq[File], outputDir: File, debug: Boolean, ignoreStatementsNotInSrcDirs: Boolean)
+  extends BaseReportWriter(sourceDirectories, outputDir, ignoreStatementsNotInSrcDirs) {
 
-  def this (sourceDir: File, outputDir: File, debug: Boolean) {
-    this(Seq(sourceDir), outputDir, debug)
+  def this (sourceDir: File, outputDir: File, debug: Boolean, ignoreStatementsNotInSrcDirs: Boolean = false) {
+    this(Seq(sourceDir), outputDir, debug, ignoreStatementsNotInSrcDirs)
   }
 
   def write(coverage: Coverage): Unit = {
     val file = IOUtils.reportFile(outputDir, debug)
-    IOUtils.writeToFile(file, new PrettyPrinter(120, 4).format(xml(coverage)))
+    IOUtils.writeToFile(file, new PrettyPrinter(120, 4).format(xml(preprocessCoverage(coverage))))
   }
 
   private def xml(coverage: Coverage): Node = {


### PR DESCRIPTION
Fixes https://github.com/scoverage/scalac-scoverage-plugin/issues/165

Adds a flag to `scoverage.report.BaseReportWriter` to optionally filter out statements from sources not in root sources.