### PR TITLE
Revert changes coming from #167 and #169.

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/BaseReportWriter.scala
@@ -2,9 +2,7 @@ package scoverage.report
 
 import java.io.File
 
-import scoverage.Coverage
-
-class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File, ignoreStatementsNotInSrcDirs: Boolean) {
+class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File) {
 
   // Source paths in canonical form WITH trailing file separator
   private val formattedSourcePaths: Seq[String] = sourceDirectories filter ( _.isDirectory ) map ( _.getCanonicalPath + File.separator )
@@ -12,7 +10,7 @@ class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File, ignoreStat
   /**
    * Converts absolute path to relative one if any of the source directories is it's parent.
    * If there is no parent directory, the path is returned unchanged (absolute).
-   *
+   * 
    * @param src absolute file path in canonical form
    */
   def relativeSource(src: String): String = relativeSource(src, formattedSourcePaths)
@@ -29,34 +27,6 @@ class BaseReportWriter(sourceDirectories: Seq[File], outputDir: File, ignoreStat
         val fmtSourcePaths: String = sourcePaths.mkString("'", "', '", "'")
         throw new RuntimeException(s"No source root found for '$canonicalSrc' (source roots: $fmtSourcePaths)");
     }
-  }
-
-  def preprocessCoverage(coverage: Coverage): Coverage = {
-    if (ignoreStatementsNotInSrcDirs)
-      filteredCoverage(coverage)
-    else
-      coverage
-  }
-
-  /**
-    * Filters out statements not in source roots
-    * @return new Coverage instance with statements whose src paths are in root source paths.
-    */
-  private def filteredCoverage(coverage: Coverage): Coverage = {
-    val filteredCoverage = Coverage()
-    coverage.statements.foreach { stmt =>
-      if (isInSourceRoots(stmt.source))
-        filteredCoverage.add(stmt)
-    }
-    coverage.ignoredStatements.foreach { stmt =>
-      if (isInSourceRoots(stmt.source))
-        filteredCoverage.addIgnoredStatement(stmt)
-    }
-    filteredCoverage
-  }
-
-  private def isInSourceRoots(src: String): Boolean = {
-    formattedSourcePaths.exists(sourcePath => src.startsWith(sourcePath))
   }
 
 }

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoberturaXmlWriter.scala
@@ -8,17 +8,16 @@ import scoverage._
 import scala.xml.{Node, PrettyPrinter}
 
 /** @author Stephen Samuel */
-class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File, ignoreStatementsNotInSrcDirs: Boolean)
-  extends BaseReportWriter(sourceDirectories, outputDir, ignoreStatementsNotInSrcDirs) {
+class CoberturaXmlWriter(sourceDirectories: Seq[File], outputDir: File) extends BaseReportWriter(sourceDirectories, outputDir) {
 
-  def this (baseDir: File, outputDir: File, ignoreStatementsNotInSrcDirs: Boolean = false) {
-    this(Seq(baseDir), outputDir, ignoreStatementsNotInSrcDirs)
+  def this (baseDir: File, outputDir: File) {
+    this(Seq(baseDir), outputDir)
   }
 
   def write(coverage: Coverage): Unit = {
     val file = new File(outputDir, "cobertura.xml")
     IOUtils.writeToFile(file, "<?xml version=\"1.0\"?>\n<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n" +
-        new PrettyPrinter(120, 4).format(xml(preprocessCoverage(coverage))))
+        new PrettyPrinter(120, 4).format(xml(coverage)))
   }
 
   def method(method: MeasuredMethod): Node = {

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -8,12 +8,11 @@ import scoverage._
 import scala.xml.Node
 
 /** @author Stephen Samuel */
-class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File, sourceEncoding: Option[String], ignoreStatementsNotInSrcDirs: Boolean)
-  extends BaseReportWriter(sourceDirectories, outputDir, ignoreStatementsNotInSrcDirs) {
+class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File, sourceEncoding: Option[String]) extends BaseReportWriter(sourceDirectories, outputDir) {
 
   // for backward compatibility only
-  def this (sourceDirectories: Seq[File], outputDir: File, ignoreStatementsNotInSrcDirs: Boolean = false) {
-    this(sourceDirectories, outputDir, None, ignoreStatementsNotInSrcDirs)
+  def this (sourceDirectories: Seq[File], outputDir: File) {
+    this(sourceDirectories, outputDir, None);
   }
   
   // for backward compatibility only
@@ -22,18 +21,16 @@ class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File, sourceE
   }
   
   def write(coverage: Coverage): Unit = {
-    val preprocessedCoverage = preprocessCoverage(coverage)
-
     val indexFile = new File(outputDir.getAbsolutePath + "/index.html")
     val packageFile = new File(outputDir.getAbsolutePath + "/packages.html")
     val overviewFile = new File(outputDir.getAbsolutePath + "/overview.html")
 
     val index = IOUtils.readStreamAsString(getClass.getResourceAsStream("/scoverage/index.html"))
     IOUtils.writeToFile(indexFile, index)
-    IOUtils.writeToFile(packageFile, packageList(preprocessedCoverage).toString())
-    IOUtils.writeToFile(overviewFile, overview(preprocessedCoverage).toString())
+    IOUtils.writeToFile(packageFile, packageList(coverage).toString())
+    IOUtils.writeToFile(overviewFile, overview(coverage).toString())
 
-    preprocessedCoverage.packages.foreach(writePackage)
+    coverage.packages.foreach(writePackage)
   }
 
   private def writePackage(pkg: MeasuredPackage): Unit = {

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageXmlWriter.scala
@@ -7,24 +7,15 @@ import scoverage._
 import scala.xml.{Node, PrettyPrinter}
 
 /** @author Stephen Samuel */
-class ScoverageXmlWriter(sourceDirectories: Seq[File], outputDir: File, debug: Boolean, ignoreStatementsNotInSrcDirs: Boolean)
-  extends BaseReportWriter(sourceDirectories, outputDir, ignoreStatementsNotInSrcDirs) {
+class ScoverageXmlWriter(sourceDirectories: Seq[File], outputDir: File, debug: Boolean) extends BaseReportWriter(sourceDirectories, outputDir) {
 
-  def this (sourceDir: File, outputDir: File, debug: Boolean, ignoreStatementsNotInSrcDirs: Boolean) {
-    this(Seq(sourceDir), outputDir, debug, ignoreStatementsNotInSrcDirs)
-  }
-
-  def this (sourceDir: File, outputDir: File, debug: Boolean){
-    this(Seq(sourceDir), outputDir, debug, ignoreStatementsNotInSrcDirs = false)
-  }
-
-  def this (sourceDirectories: Seq[File], outputDir: File, debug: Boolean) {
-    this(sourceDirectories, outputDir, debug, ignoreStatementsNotInSrcDirs = false)
+  def this (sourceDir: File, outputDir: File, debug: Boolean) {
+    this(Seq(sourceDir), outputDir, debug)
   }
 
   def write(coverage: Coverage): Unit = {
     val file = IOUtils.reportFile(outputDir, debug)
-    IOUtils.writeToFile(file, new PrettyPrinter(120, 4).format(xml(preprocessCoverage(coverage))))
+    IOUtils.writeToFile(file, new PrettyPrinter(120, 4).format(xml(coverage)))
   }
 
   private def xml(coverage: Coverage): Node = {


### PR DESCRIPTION
These PRs fix #165.

It's unclear what the problem really is. Issue author has "No source root found for ${sourcepath}" exception in Gradle
project. We cannot reproduce the problem. This must be something with user's project configuration or a bug in Gradle plugin.

The two PRs were merged hastily all will be reverted.

@pbatko please provide test project and report problem in [Gradle Scoverage plugin](https://github.com/scoverage/gradle-scoverage/issues) first.