### PR TITLE
Scala 2.12.0-RC1 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ language: scala
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
 
-jdk:
-  - oraclejdk7
-
-scala:
-  - 2.10.6
-  - 2.11.8
+matrix:
+  include:
+    - jdk: oraclejdk7
+      scala: 2.10.6
+    - jdk: oraclejdk7
+      scala: 2.11.8
+    - jdk: oraclejdk8
+      scala: 2.12.0-RC1
 
 before_cache:
   - find "$HOME/.sbt/" -name '*.lock' -print0 | xargs -0 rm

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val ScalatestVersion = "3.0.0"
 val appSettings = Seq(
     organization := Org,
     scalaVersion := "2.11.8",
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-RC1"),
     fork in Test := false,
     publishMavenStyle := true,
     publishArtifact in Test := false,
@@ -90,13 +90,15 @@ lazy val plugin = Project("scalac-scoverage-plugin", file("scalac-scoverage-plug
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
     "org.joda" % "joda-convert" % "1.6" % "test",
-    "joda-time" % "joda-time" % "2.3" % "test",
-    "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2" % "test"
+    "joda-time" % "joda-time" % "2.3" % "test"
   )).settings(libraryDependencies ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, scalaMajor)) if scalaMajor == 11 =>
-        Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.4")
-      case _ =>
-        Nil
+      case Some((2, scalaMajor)) if scalaMajor > 10 => Seq(
+        "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
+        "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0" % "test"
+      )
+      case _ => Seq(
+        "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2" % "test"
+      )
     }
   })

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
@@ -8,7 +8,8 @@ class PluginASTSupportTest
   extends FunSuite
   with MockitoSugar
   with OneInstancePerTest
-  with BeforeAndAfterEachTestData {
+  with BeforeAndAfterEachTestData
+  with ScalaLoggingSupport {
 
   override protected def afterEach(testData: TestData): Unit = {
     val compiler = ScoverageCompiler.default
@@ -62,7 +63,7 @@ class PluginASTSupportTest
     assert(!compiler.reporter.hasErrors)
   }
 
- // https://github.com/scoverage/scalac-scoverage-plugin/issues/32
+  // https://github.com/scoverage/scalac-scoverage-plugin/issues/32
   test("exhaustive warnings should not be generated for @unchecked") {
     val compiler = ScoverageCompiler.default
     compiler.compileCodeSnippet( """object PartialMatchObject {
@@ -79,10 +80,8 @@ class PluginASTSupportTest
   // https://github.com/skinny-framework/skinny-framework/issues/97
   test("macro range positions should not break plugin") {
     val compiler = ScoverageCompiler.default
-    compiler.addToClassPath("org.slf4j", "slf4j-api", "1.7.7")
-    compiler.addToClassPath("com.typesafe.scala-logging", "scala-logging-api_" + ScoverageCompiler.ShortScalaVersion, "2.1.2")
-    compiler.addToClassPath("com.typesafe.scala-logging", "scala-logging-slf4j_" + ScoverageCompiler.ShortScalaVersion, "2.1.2")
-    compiler.compileCodeSnippet( """import com.typesafe.scalalogging.slf4j.StrictLogging
+    scalaLoggingDeps.foreach(compiler.addToClassPath(_))
+    compiler.compileCodeSnippet( s"""import ${scalaLoggingPackageName}.StrictLogging
                           |
                           |object MacroTest extends StrictLogging {
                           |  println("Hello")

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -8,7 +8,8 @@ class PluginCoverageTest
   extends FunSuite
   with MockitoSugar
   with OneInstancePerTest
-  with BeforeAndAfterEachTestData {
+  with BeforeAndAfterEachTestData
+  with ScalaLoggingSupport {
 
   test("scoverage should instrument default arguments with methods") {
     val compiler = ScoverageCompiler.default
@@ -287,16 +288,8 @@ class PluginCoverageTest
 
   test("plugin should not instrument expanded macro code github.com/skinny-framework/skinny-framework/issues/97") {
     val compiler = ScoverageCompiler.default
-    compiler.addToClassPath("org.slf4j", "slf4j-api", "1.7.7")
-    compiler
-      .addToClassPath("com.typesafe.scala-logging",
-        "scala-logging-api_" + ScoverageCompiler.ShortScalaVersion,
-        "2.1.2")
-    compiler
-      .addToClassPath("com.typesafe.scala-logging",
-        "scala-logging-slf4j_" + ScoverageCompiler.ShortScalaVersion,
-        "2.1.2")
-    compiler.compileCodeSnippet( """import com.typesafe.scalalogging.slf4j.StrictLogging
+    scalaLoggingDeps.foreach(compiler.addToClassPath(_))
+    compiler.compileCodeSnippet( s"""import ${scalaLoggingPackageName}.StrictLogging
                                    |class MacroTest extends StrictLogging {
                                    |  logger.info("will break")
                                    |} """.stripMargin)

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScalaLoggingSupport.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScalaLoggingSupport.scala
@@ -1,0 +1,48 @@
+package scoverage
+
+import java.io.{File, FileNotFoundException}
+import java.net.URL
+
+import scala.collection.mutable.ListBuffer
+import scala.tools.nsc.{Settings, Global}
+import scala.tools.nsc.plugins.PluginComponent
+import scala.tools.nsc.transform.{Transform, TypingTransformers}
+
+trait ScalaLoggingSupport {
+
+  val scalaLoggingPackageName: String = if (ScoverageCompiler.ShortScalaVersion == "2.10") {
+    "com.typesafe.scalalogging.slf4j"
+  }
+  else {
+    "com.typesafe.scalalogging"
+  }
+
+  lazy val scalaLoggingDeps: Seq[File] = {
+    if (ScoverageCompiler.ShortScalaVersion == "2.10") {
+      Seq(
+        findIvyJar("org.slf4j", "slf4j-api", "1.7.7"),
+        findCrossedIvyJar("com.typesafe.scala-logging", "scala-logging-api", "2.1.2"),
+        findCrossedIvyJar("com.typesafe.scala-logging", "scala-logging-slf4j", "2.1.2")
+      )
+    }
+    else {
+      Seq(
+        findIvyJar("org.slf4j", "slf4j-api", "1.7.21"),
+        findCrossedIvyJar("com.typesafe.scala-logging", "scala-logging", "3.5.0", "bundle")
+      )
+    }
+  }
+
+  private def findCrossedIvyJar(groupId: String, artifactId: String, version: String, packaging: String = "jar"): File =
+    findIvyJar(groupId, artifactId + "_" + ScoverageCompiler.ShortScalaVersion, version, packaging)
+
+  private def findIvyJar(groupId: String, artifactId: String, version: String, packaging: String = "jar"): File = {
+    val userHome = System.getProperty("user.home")
+    val jarPath = s"$userHome/.ivy2/cache/$groupId/$artifactId/${packaging}s/${artifactId}-${version}.jar"
+    val file = new File(jarPath)
+    if (!file.exists)
+      throw new FileNotFoundException(s"Could not locate [$jarPath].")
+    file
+  }
+
+}


### PR DESCRIPTION
- add Scala 2.12.0-RC1 to build file and Travis configuration,
- improve test harness:
  - use different `scala-logging` library versions for different Scala versions - there is no version supporting Scala versions from 2.10 to 2.12,
  - change compiler phase from `dce` to `jvm` in `runsAfter` method - `dce` phase was removed in Scala 2.12.

This PR replaces #177.