### PR TITLE
Fix splitting source into lines on Windows OS when source file contains Linux line ending characters ("\n").

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CodeGrid.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CodeGrid.scala
@@ -14,7 +14,7 @@ class CodeGrid(mFile: MeasuredFile, sourceEncoding: Option[String]) {
 
   case class Cell(char: Char, var status: StatementStatus)
 
-  private val lineBreak = System.getProperty("line.separator")
+  private val lineBreak = "\n"
 
   // Array of lines, each line is an array of cells, where a cell is a character + coverage info for that position
   // All cells default to NoData until the highlighted information is applied


### PR DESCRIPTION
In this case code grid report doesn't split source file into lines at all because it tries to split on Windows line ending sequence ("\r\n") and there is no such sequence in source file.

'\r' characters should be treated as every other character (as it's treated now on Linux OS when source file contains Windows line ending sequences). Only '\n' characters should be used to split source into lines. It will work even if source file has mixed line endings.
