### PR TITLE
Update Scala version to 2.12.0 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - jdk: oraclejdk7
       scala: 2.11.8
     - jdk: oraclejdk8
-      scala: 2.12.0-RC1
+      scala: 2.12.0
 
 before_cache:
   - find "$HOME/.sbt/" -name '*.lock' -print0 | xargs -0 rm

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ val ScalatestVersion = "3.0.0"
 
 val appSettings = Seq(
     organization := Org,
-    scalaVersion := "2.11.8",
-    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-RC2"),
+    scalaVersion := "2.12.0",
+    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
     fork in Test := false,
     publishMavenStyle := true,
     publishArtifact in Test := false,


### PR DESCRIPTION
Updates Scala to 2.12.0 final and makes this the default Scala version.

With this published, I hope the plugins can be updated accordingly, too :)