### PR TITLE
Improve instrumentation of "try" statement without "finally" section

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
@@ -570,7 +570,7 @@ class ScoverageInstrumentationComponent(val global: Global, extraAfterPhase: Opt
           treeCopy.Try(tree,
             instrument(process(t), t, branch = true),
             transformCases(cases),
-            instrument(process(f), f, branch = true))
+            if (f.isEmpty) f else instrument(process(f), f, branch = true))
 
         // type aliases, type parameters, abstract types
         case t: TypeDef => super.transform(tree)


### PR DESCRIPTION
Instrument `finally` section only if it is present.

It wasn't instrumented before when it was missing, but `Could not instrument [EmptyTree$/null]. No pos.` warning was emitted. Now `instrument` method will be called only if `finnaly` section is present.

This fixes many (if not all) remaining `Could not instrument [EmptyTree$/null]. No pos.` warnings reported in #5 