### PR TITLE
Upgrade SBT version from 0.13.13 to 1.0.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")


### PR DESCRIPTION
Changes:

- upgrade SBT version from 0.13.13 to 1.0.2,

- upgrade plugin versions to SBT 1.0.x compatible ones:
  - upgrade ScalaStyle plugin version from 0.8.0 to 1.0.0,
  - upgrade PGP plugin version from 1.0.1 to 1.1.0,
  - upgrade Release plugin version from 1.0.3 to 1.0.6.