### PR TITLE
Add Scala 2.13.0-M2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - jdk: oraclejdk8
       scala: 2.12.4
     - jdk: oraclejdk8
-      scala: 2.13.0-M1
+      scala: 2.13.0-M2
 
 before_cache:
   - find "$HOME/.sbt/" -name '*.lock' -print0 | xargs -0 rm

--- a/build.sbt
+++ b/build.sbt
@@ -8,12 +8,12 @@ import org.scalajs.sbtplugin.cross.CrossType
 
 val Org = "org.scoverage"
 val MockitoVersion = "1.10.19"
-val ScalatestVersion = "3.0.3"
+val ScalatestVersion = "3.0.4"
 
 val appSettings = Seq(
     organization := Org,
     scalaVersion := "2.12.4",
-    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4", "2.13.0-M1"),
+    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4", "2.13.0-M2"),
     fork in Test := false,
     publishMavenStyle := true,
     publishArtifact in Test := false,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")


### PR DESCRIPTION
- upgrade Scala version from 2.13.0-M1 to 2.13.0-M2 in `build.sbt` and `.travis.yml`

- downgrade SBT version from 1.0.2 to 0.13.16 (1)
- upgrade scala-js version from 0.6.19 to 0.6.20 (2)

- upgrade scalatest version from 3.0.3 to 3.0.4

(1)

SBT 1.0.2 is not compatible with Scala 2.13.0-M2 and 0.13.16 surpisingly is.

SBT 1.0.2 error stack trace:

[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.13.0-M2. Compiling...
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:11: error: object ILoop is not a member of package scala.tools.nsc.interpreter
import scala.tools.nsc.interpreter.{ ILoop, IMain, InteractiveReader, NamedParam }
       ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:41: error: not found: type ILoop
    val loop = new ILoop {
                   ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:44: error: not found: value in
          in = InteractiveReader.apply()
          ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:45: error: not found: value intp
          intp = new IMain(settings) {
          ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:52: error: not found: value intp
          intp.setContextClassLoader()
          ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:54: error: value createInterpreter is not a member of AnyRef
          super.createInterpreter()
                ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:57: error: not found: value intp
          intp.quietBind(NamedParam.clazz(id, value))
          ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:60: error: not found: value intp
          intp.interpret(initialCommands)
          ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\ConsoleInterface.scala:67: error: not found: value intp
          intp.interpret(cleanupCommands)
          ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\InteractiveConsoleHelper.scala:10: error: object IR is not a member of package scala.tools.nsc.interpreter
import scala.tools.nsc.interpreter.IR
       ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\InteractiveConsoleHelper.scala:14: error: not found: value IR
  implicit def toConsoleResult(ir: IR.Result): InteractiveConsoleResult =
                                   ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\InteractiveConsoleHelper.scala:16: error: not found: value IR
      case IR.Success    => InteractiveConsoleResult.Success
           ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\InteractiveConsoleHelper.scala:17: error: not found: value IR
      case IR.Incomplete => InteractiveConsoleResult.Incomplete
           ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\InteractiveConsoleHelper.scala:18: error: not found: value IR
      case IR.Error      => InteractiveConsoleResult.Error
           ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\InteractiveConsoleInterface.scala:41: error: type mismatch;
 found   : java.io.PrintWriter
 required: scala.tools.nsc.interpreter.ReplReporter
  val interpreter: IMain = new IMain(compilerSettings, new PrintWriter(outWriter)) {
                                                       ^
D:\home\gs\Temp\sbt_d40370ee\xsbt\InteractiveConsoleInterface.scala:48: error: type mismatch;
 found   : tools.nsc.interpreter.Results.Result
 required: xsbti.InteractiveConsoleResult
    InteractiveConsoleResponse(r, outWriter.toString)
                               ^
16 errors found

(2)

With version 0.6.19 tests fail with NullPointerException (after successfully executing all tests):

[info] Tests: succeeded 89, failed 0, canceled 0, ignored 1, pending 0
[info] All tests passed.
java.lang.NullPointerException
	at scala.collection.convert.Wrappers$JMapWrapperLike$$anon$2.<init>(Wrappers.scala:265)
	at scala.collection.convert.Wrappers$JMapWrapperLike$class.iterator(Wrappers.scala:264)
	at scala.collection.convert.Wrappers$JMapWrapper.iterator(Wrappers.scala:275)
	at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	at scala.collection.TraversableOnce$class.toMap(TraversableOnce.scala:279)
	at scala.collection.AbstractTraversable.toMap(Traversable.scala:105)
	at org.scalajs.core.tools.json.Impl$.toMap(Impl.scala:26)
	at org.scalajs.core.tools.json.JSONObjExtractor.<init>(JSONObjExtractor.scala:6)
	at org.scalajs.testadapter.FrameworkInfo$Deserializer$.deserialize(FrameworkInfo.scala:24)
	at org.scalajs.testadapter.FrameworkInfo$Deserializer$.deserialize(FrameworkInfo.scala:22)
	at org.scalajs.core.tools.json.package$.fromJSON(package.scala:19)
	at org.scalajs.testadapter.ScalaJSFramework.fetchFrameworkInfo(ScalaJSFramework.scala:66)
	at org.scalajs.testadapter.ScalaJSFramework.<init>(ScalaJSFramework.scala:37)
	at org.scalajs.sbtplugin.ScalaJSPluginInternal$$anonfun$76$$anonfun$apply$54.apply(ScalaJSPluginInternal.scala:915)
	at org.scalajs.sbtplugin.ScalaJSPluginInternal$$anonfun$76$$anonfun$apply$54.apply(ScalaJSPluginInternal.scala:914)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
	at scala.collection.immutable.Map$Map1.foreach(Map.scala:109)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
	at scala.collection.AbstractTraversable.map(Traversable.scala:105)
	at org.scalajs.sbtplugin.ScalaJSPluginInternal$$anonfun$76.apply(ScalaJSPluginInternal.scala:914)
	at org.scalajs.sbtplugin.ScalaJSPluginInternal$$anonfun$76.apply(ScalaJSPluginInternal.scala:891)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
[error] (scalac-scoverage-runtimeJS/test:loadedTestFrameworks) java.lang.NullPointerException