### PR TITLE
Fixed #183: JSDOMNodeJSEnv is handled incorrectly (Scalajs support)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,11 @@ lazy val runtime = CrossProject("scalac-scoverage-runtime", file("scalac-scovera
       libraryDependencies += "org.scalatest" %%% "scalatest" % ScalatestVersion % "test",
       scalaJSStage := FastOptStage,
       inConfig(Test)(jsEnv := RhinoJSEnv().value)
+      //
+      // to test using Node.js env
+      //
+      //inConfig(Test)(jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv()),
+      //requiresDOM in Test := true
     )
 
 lazy val `scalac-scoverage-runtimeJVM` = runtime.jvm

--- a/scalac-scoverage-runtime/js/src/main/scala/scalajssupport/File.scala
+++ b/scalac-scoverage-runtime/js/src/main/scala/scalajssupport/File.scala
@@ -57,9 +57,10 @@ class File(path: String) {
 }
 
 object File {
-  val jsFile: JsFileObject = if (js.Dynamic.global.hasOwnProperty("Packages").asInstanceOf[Boolean])
+
+  private val jsFile: JsFileObject = if (g.hasOwnProperty("Packages").asInstanceOf[Boolean])
     RhinoFile
-  else if (!js.Dynamic.global.hasOwnProperty("window").asInstanceOf[Boolean])
+  else if (js.typeOf(g.global) == "object" && js.typeOf(g.global.require) == "function")
     NodeFile
   else
     PhantomFile

--- a/scalac-scoverage-runtime/js/src/main/scala/scalajssupport/NodeFile.scala
+++ b/scalac-scoverage-runtime/js/src/main/scala/scalajssupport/NodeFile.scala
@@ -1,6 +1,7 @@
 package scalajssupport
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
 
 class NodeFile(path: String) extends JsFile {
   def this(path: String, child: String) = {
@@ -85,9 +86,17 @@ trait NodePath extends js.Object {
   def join(paths: String*): String = js.native
 }
 
+@js.native
+@JSGlobal("global")
+object NodeJsGlobal extends js.Object {
+  def require(module: String): js.Any = js.native
+}
+
 private[scalajssupport] object NodeFile extends JsFileObject {
-  val fs: FS = js.Dynamic.global.require("fs").asInstanceOf[FS]
-  val nodePath: NodePath = js.Dynamic.global.require("path").asInstanceOf[NodePath]
+
+  private val fs: FS = NodeJsGlobal.require("fs").asInstanceOf[FS]
+  private val nodePath: NodePath = NodeJsGlobal.require("path").asInstanceOf[NodePath]
+
   def write(path: String, data: String, mode: String = "a") = {
     fs.writeFileSync(path, data, js.Dynamic.literal(flag = mode))
   }


### PR DESCRIPTION
In order to detect Node.js environment I'm using the `global` object, approach suggested here:
https://www.scala-js.org/doc/interoperability/global-scope.html

```scala
if (js.typeOf(g.global) == "object" && js.typeOf(g.global.require) == "function") {
    // Node.js environment detected
    NodeFile
}
```