### PR TITLE
Don't use deprecated 'RhinoJSEnv' class in the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,8 +73,7 @@ lazy val runtime = CrossProject("scalac-scoverage-runtime", file("scalac-scovera
     )
     .jsSettings(
       libraryDependencies += "org.scalatest" %%% "scalatest" % ScalatestVersion % "test",
-      scalaJSStage := FastOptStage,
-      inConfig(Test)(jsEnv := RhinoJSEnv().value)
+      scalaJSStage := FastOptStage
     )
 
 lazy val `scalac-scoverage-runtimeJVM` = runtime.jvm


### PR DESCRIPTION
As the warning says, it's deprecated since [scala-js](https://github.com/scala-js/scala-js/) `0.6.13`:

```
warning: method RhinoJSEnv in object AutoImport is deprecated (since 0.6.13): The Rhino JS environment is being phased out. It will be removed in Scala.js 1.0.0.
      inConfig(Test)(jsEnv := RhinoJSEnv().value)
                              ^
```

Check [this commit](https://github.com/scala-js/scala-js/commit/55f46885fa4bde51a0d26532b1f0520111a1be28) in `scala-js` project.