### PR TITLE
Remove 'org.mockito:mockito-core' dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ import sbtcrossproject.CrossProject
 import sbtcrossproject.CrossType
 
 val Org = "org.scoverage"
-val MockitoVersion = "2.19.0"
 val ScalatestVersion = "3.0.6-SNAP4"
 
 val appSettings = Seq(
@@ -66,10 +65,7 @@ lazy val runtime = CrossProject("scalac-scoverage-runtime", file("scalac-scovera
     .settings(name := "scalac-scoverage-runtime")
     .settings(appSettings: _*)
     .jvmSettings(
-      libraryDependencies ++= Seq(
-      "org.mockito" % "mockito-core" % MockitoVersion % "test",
-      "org.scalatest" %% "scalatest" % ScalatestVersion % "test"
-      )
+      libraryDependencies += "org.scalatest" %% "scalatest" % ScalatestVersion % "test"
     )
     .jsSettings(
       libraryDependencies += "org.scalatest" %%% "scalatest" % ScalatestVersion % "test",
@@ -84,7 +80,6 @@ lazy val plugin = Project("scalac-scoverage-plugin", file("scalac-scoverage-plug
     .settings(name := "scalac-scoverage-plugin")
     .settings(appSettings: _*)
     .settings(libraryDependencies ++= Seq(
-    "org.mockito" % "mockito-core" % MockitoVersion % "test",
     "org.scalatest" %% "scalatest" % ScalatestVersion % "test",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
   )).settings(libraryDependencies ++= {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/IOUtilsTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/IOUtilsTest.scala
@@ -3,11 +3,10 @@ package scoverage
 import java.io.{File, FileWriter}
 import java.util.UUID
 
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest}
 
 /** @author Stephen Samuel */
-class IOUtilsTest extends FreeSpec with MockitoSugar with OneInstancePerTest with Matchers {
+class IOUtilsTest extends FreeSpec with OneInstancePerTest with Matchers {
 
   "io utils" - {
     "should parse measurement files" in {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
@@ -1,12 +1,10 @@
 package scoverage
 
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest._
 
 /** @author Stephen Samuel */
 class PluginASTSupportTest
   extends FunSuite
-  with MockitoSugar
   with OneInstancePerTest
   with BeforeAndAfterEachTestData
   with ScalaLoggingSupport {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -1,12 +1,10 @@
 package scoverage
 
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEachTestData, FunSuite, OneInstancePerTest}
 
 /** @author Stephen Samuel */
 class PluginCoverageTest
   extends FunSuite
-  with MockitoSugar
   with OneInstancePerTest
   with BeforeAndAfterEachTestData
   with ScalaLoggingSupport {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
@@ -1,13 +1,11 @@
 package scoverage
 
-import org.mockito.Mockito
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FreeSpec, Matchers}
 
-import scala.reflect.internal.util._
-import scala.reflect.io.AbstractFile
+import scala.reflect.internal.util.{BatchSourceFile, NoFile, SourceFile}
+import scala.reflect.io.VirtualFile
 
-class RegexCoverageFilterTest extends FreeSpec with Matchers with MockitoSugar {
+class RegexCoverageFilterTest extends FreeSpec with Matchers {
 
   "isClassIncluded" - {
 
@@ -40,8 +38,7 @@ class RegexCoverageFilterTest extends FreeSpec with Matchers with MockitoSugar {
     }
   }
   "isFileIncluded" - {
-    val abstractFile = mock[AbstractFile]
-    Mockito.when(abstractFile.path).thenReturn("sammy.scala")
+    val abstractFile = new VirtualFile("sammy.scala")
     "should return true for empty excludes" in {
       val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
       new RegexCoverageFilter(Nil, Nil, Nil).isFileIncluded(file) shouldBe true

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
@@ -3,9 +3,8 @@ package scoverage
 import java.io.StringWriter
 
 import org.scalatest.{OneInstancePerTest, FunSuite}
-import org.scalatest.mockito.MockitoSugar
 
-class SerializerTest extends FunSuite with MockitoSugar with OneInstancePerTest {
+class SerializerTest extends FunSuite with OneInstancePerTest {
 
   test("coverage should be serializable into plain text") {
     val coverage = Coverage()


### PR DESCRIPTION
It was needed only in one place.

`scala.reflect.io.VirtualFile` can be used instead of mocking `scala.reflect.io.AbstractFile`.