### PR TITLE
Fix different compilation warnings

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
@@ -28,7 +28,7 @@ object CoverageAggregator {
       if (coverageFile.exists) {
         val subcoverage: Coverage = Serializer.deserialize(coverageFile)
         val measurementFiles: Array[File] = IOUtils.findMeasurementFiles(dataDir)
-        val measurements = IOUtils.invoked(measurementFiles)
+        val measurements = IOUtils.invoked(measurementFiles.toIndexedSeq)
         subcoverage.apply(measurements)
         subcoverage.statements foreach { stmt =>
           // need to ensure all the ids are unique otherwise the coverage object will have stmt collisions

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageMetricsTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageMetricsTest.scala
@@ -21,7 +21,7 @@ class CoverageMetricsTest extends FreeSpec with Matchers {
       override def ignoredStatements: Iterable[Statement] = Seq()
     }
     metrics.branchCount shouldBe 0
-    metrics.branchCoverage - 1 shouldBe < (0.0001)
+    metrics.branchCoverage shouldBe 1.0 +- 0.0001
   }
 
   "no branches with no invoked statements should have 0% branch coverage" in {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/LocationTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/LocationTest.scala
@@ -187,8 +187,6 @@ class LocationTest extends FreeSpec with Matchers {
       compiler
         .compile(
           "package com.a; object A { def foo(b : B) : Unit = b.invoke }; trait B { def invoke : Unit }; class C { A.foo(new B { def invoke = () }) }")
-      println()
-      println(compiler.locations.result().mkString("\n"))
       val loc = compiler.locations.result().filter(_._1 == "Template").last._2
       loc.packageName shouldBe "com.a"
       loc.className shouldBe "C"

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/MacroSupport.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/MacroSupport.scala
@@ -4,6 +4,13 @@ import java.io.File
 
 trait MacroSupport {
 
+  val macroContextPackageName: String = if (ScoverageCompiler.ShortScalaVersion == "2.10") {
+    "scala.reflect.macros"
+  }
+  else {
+    "scala.reflect.macros.blackbox"
+  }
+
   val macroSupportDeps = Seq(testClasses)
 
   private def testClasses: File = new File(s"./scalac-scoverage-plugin/target/scala-${ScoverageCompiler.ShortScalaVersion}/test-classes")

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
@@ -83,11 +83,11 @@ class PluginASTSupportTest
 
   test("scoverage component should ignore basic macros") {
     val compiler = ScoverageCompiler.default
-    compiler.compileCodeSnippet( """
+    compiler.compileCodeSnippet( s"""
                           | object MyMacro {
                           | import scala.language.experimental.macros
-                          | import scala.reflect.macros.Context
-                          |  def test = macro testImpl
+                          | import ${macroContextPackageName}.Context
+                          |  def test: Unit = macro testImpl
                           |  def testImpl(c: Context): c.Expr[Unit] = {
                           |    import c.universe._
                           |    reify {
@@ -100,12 +100,12 @@ class PluginASTSupportTest
 
   test("scoverage component should ignore complex macros #11") {
     val compiler = ScoverageCompiler.default
-    compiler.compileCodeSnippet( """ object ComplexMacro {
+    compiler.compileCodeSnippet( s""" object ComplexMacro {
                           |
                           |  import scala.language.experimental.macros
-                          |  import scala.reflect.macros.Context
+                          |  import ${macroContextPackageName}.Context
                           |
-                          |  def debug(params: Any*) = macro debugImpl
+                          |  def debug(params: Any*): Unit = macro debugImpl
                           |
                           |  def debugImpl(c: Context)(params: c.Expr[Any]*) = {
                           |    import c.universe._
@@ -114,7 +114,7 @@ class PluginASTSupportTest
                           |      case Literal(Constant(_)) => reify { print(param.splice) }
                           |      case _ => reify {
                           |        val variable = c.Expr[String](Literal(Constant(show(param.tree)))).splice
-                          |        print(s"$variable = ${param.splice}")
+                          |        print(s"$$variable = $${param.splice}")
                           |      }
                           |    }).tree
                           |    }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -35,18 +35,18 @@ class PluginCoverageTest
               }
 
               object Macros {
-                def poly[T] = macro Impl.poly[T]
+                def poly[T]: String = macro Impl.poly[T]
               }"""
     else
-               """
+               s"""
               import scala.language.experimental.macros
-              import scala.reflect.macros.Context
+              import scala.reflect.macros.blackbox.Context
               class Impl(val c: Context) {
                 import c.universe._
-                def poly[T: c.WeakTypeTag] = c.literal(c.weakTypeOf[T].toString)
+                def poly[T: c.WeakTypeTag] = q"$${c.weakTypeOf[T].toString}"
               }
               object Macros {
-                def poly[T] = macro Impl.poly[T]
+                def poly[T]: String = macro Impl.poly[T]
               }"""
     compiler.compileCodeSnippet(code)
     assert(!compiler.reporter.hasErrors)
@@ -269,11 +269,11 @@ class PluginCoverageTest
 
   test("plugin should not instrument local macro implementation") {
     val compiler = ScoverageCompiler.default
-    compiler.compileCodeSnippet( """
+    compiler.compileCodeSnippet( s"""
                                    | object MyMacro {
                                    | import scala.language.experimental.macros
-                                   | import scala.reflect.macros.Context
-                                   |  def test = macro testImpl
+                                   | import ${macroContextPackageName}.Context
+                                   |  def test: Unit = macro testImpl
                                    |  def testImpl(c: Context): c.Expr[Unit] = {
                                    |    import c.universe._
                                    |    reify {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -22,6 +22,7 @@ object ScoverageCompiler {
   def settings: Settings = {
     val s = new scala.tools.nsc.Settings
     s.Xprint.value = List("all")
+    s.deprecation.value = true
     s.Yrangepos.value = true
     s.Yposdebug.value = true
     s.classpath.value = classPath.mkString(File.pathSeparator)


### PR DESCRIPTION
From time to time it's good to fix the warnings, because they sometimes turn into errors in next Scala versions.