### PR TITLE
making scoverage work with classpaths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,6 @@ lazy val runtime = CrossProject("scalac-scoverage-runtime", file("scalac-scovera
     .settings(appSettings: _*)
     .jvmSettings(
       fork in Test := true,
-      envVars in Test := Map("SCOVERAGE_MEASUREMENT_PATH" -> "scoverageMeasurementFiles"),
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % ScalatestVersion % "test"
       )

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,10 @@ lazy val runtime = CrossProject("scalac-scoverage-runtime", file("scalac-scovera
     .settings(appSettings: _*)
     .jvmSettings(
       fork in Test := true,
-      libraryDependencies += "org.scalatest" %% "scalatest" % ScalatestVersion % "test"
+      envVars in Test := Map("SCOVERAGE_MEASUREMENT_PATH" -> "scoverageMeasurementFiles"),
+      libraryDependencies ++= Seq(
+        "org.scalatest" %% "scalatest" % ScalatestVersion % "test"
+      )
     )
     .jsSettings(
       libraryDependencies += "org.scalatest" %%% "scalatest" % ScalatestVersion % "test",

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/Constants.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/Constants.scala
@@ -7,7 +7,7 @@ object Constants {
   // directory that contains all the measurement data but not reports
   val DataDir = "scoverage-data"
   /*********************************************************************
-   * If updating any of the files below, an update is also required to *
+   * If updating any of the file names below, an update is also required to *
    * the corresponding file name in Invoker.scala                      *
    *********************************************************************/
   // the file that contains the statement mappings

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/Constants.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/Constants.scala
@@ -1,13 +1,19 @@
 package scoverage
 
 object Constants {
-  // the file that contains the statement mappings
-  val CoverageFileName = "scoverage.coverage"
   // the final scoverage report
   val XMLReportFilename = "scoverage.xml"
   val XMLReportFilenameWithDebug = "scoverage-debug.xml"
   // directory that contains all the measurement data but not reports
   val DataDir = "scoverage-data"
+  /*********************************************************************
+   * If updating any of the files below, an update is also required to *
+   * the corresponding file name in Invoker.scala                      *
+   *********************************************************************/
+  // the file that contains the statement mappings
+  val CoverageFileName = "scoverage.coverage"
   // the prefix the measurement files have
   val MeasurementsPrefix = "scoverage.measurements."
+  //subdir to suffix to classpath when [writeToClasspath] option is in use"
+  val ClasspathSubdir = "META-INF/scoverage"
 }

--- a/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/plugin.scala
@@ -34,9 +34,7 @@ class ScoveragePlugin(val global: Global) extends Plugin {
         options.dataDir = opt.substring("dataDir:".length)
       } else if (opt.startsWith("extraAfterPhase:") || opt.startsWith("extraBeforePhase:")) {
         // skip here, these flags are processed elsewhere
-      } else if (opt.startsWith("classpathSubdir:")){
-        options.classpathSubdir = opt.substring("classpathSubdir:".length)
-      }else if (opt.startsWith("writeToClasspath:")) {
+      } else if (opt.startsWith("writeToClasspath:")) {
         try {
           options.writeToClasspath = opt.substring("writeToClasspath:".length).toBoolean
         } catch {
@@ -56,10 +54,10 @@ class ScoveragePlugin(val global: Global) extends Plugin {
   }
 
   override val optionsHelp: Option[String] = Some(Seq(
-    "-P:scoverage:writeToClasspath:<boolean>               if true, use the environment variable to store measurements" +
-                                                           "and store instruments to the output classpath where compiler emits classfiles." +
+    "-P:scoverage:writeToClasspath:<boolean>               if true, use the system property variable [scoverage_measurement_path]" +
+                                                           " to store measurements " +
+                                                           "and store instruments file to the output classpath where compiler emits classfiles. " +
                                                            "Overrides the datadir with the output classpath.",
-    "-P:scoverage:classpathSubdir:<pathtosubdir>           subdir to attach to classpath. Default: META-INF/scoverage",
 
     "-P:scoverage:dataDir:<pathtodatadir>                  where the coverage files should be written\n",
     "-P:scoverage:excludedPackages:<regex>;<regex>         semicolon separated list of regexs for packages to exclude",
@@ -101,13 +99,12 @@ class ScoverageOptions {
 
   // Adding additional option for https://github.com/scoverage/scalac-scoverage-plugin/issues/265
   // If the option is false, scoverage works the usual way.
-  // If the option is true, the instruments are stored on to the classpath and
-  // the measurements are written to the directory specified by the environment variable
-  // `SCOVERAGE_MEASUREMENT_PATH`. This means setting [writeToClasspath] to true overrides the [dataDir]
+  // If the option is true, the instrument files [scoverage.coverage] are stored on to the classpath and
+  // the measurement files are written to the directory specified by the system property
+  // `scoverage_measurement_path`. This means setting [writeToClasspath] to true overrides the [dataDir]
   // as the [dataDir] will now point to the output classpath of the compiler.
   // By default, the option is set to false.
   var writeToClasspath: Boolean = false
-  var classpathSubdir: String = "META-INF/scoverage"
 }
 
 class ScoverageInstrumentationComponent(val global: Global, extraAfterPhase: Option[String], extraBeforePhase: Option[String])
@@ -133,6 +130,27 @@ class ScoverageInstrumentationComponent(val global: Global, extraAfterPhase: Opt
   private var options: ScoverageOptions = new ScoverageOptions()
   private var coverageFilter: CoverageFilter = AllCoverageFilter
 
+  // This [targetId] is used below in case [writeToClasspath] option
+  // is true. It is used for:
+  // 1. Creating a unique subdir under the classpath to store the instrument files, i.e
+  //    path to instrument files will be `< classpath >/META-INF/scoverage/< targetId >/scoverage.coverage`
+  // 2. Instrumenting the binaries with the [targetId], i.e binaries will be instrumented with
+  //    `Invoker.invokedWriteToClasspath(< statement id >, < targetId >)`
+  //    Consequently, at runtime, we can get the "correct" instrument file located at `.../< targetId >/scoverage.coverage`
+  //    from the classpath and store it with its appropriate measurements file.
+  private var targetId: String = ""
+
+  // used for generating the targetId.
+  def md5HashString(s: String): String = {
+    import java.security.MessageDigest
+    import java.math.BigInteger
+    val md = MessageDigest.getInstance("MD5")
+    val digest = md.digest(s.getBytes)
+    val bigInt = new BigInteger(1,digest)
+    val hashedString = bigInt.toString(16)
+    hashedString
+  }
+
   def setOptions(options: ScoverageOptions): Unit = {
 
     this.options = options
@@ -142,7 +160,11 @@ class ScoverageInstrumentationComponent(val global: Global, extraAfterPhase: Opt
     // i.e to the directory where compiler is going to output the classfiles.
     if(options.writeToClasspath){
       settings.outputDirs.getSingleOutput match {
-        case Some(dest) => options.dataDir = s"${dest.toString()}/${options.classpathSubdir}"
+        case Some(dest) =>
+          targetId = md5HashString(s"${dest.toString()}")
+          // Setting [dataDir] to `< classpath >/META-INF/scoverage/< targetId >`.
+          // This is where the instrument file [scoverage.coverage] for this target will now be stored.
+          options.dataDir = s"${dest.toString()}/${Constants.ClasspathSubdir}/$targetId"
         case None => throw new RuntimeException("No output classpath specified.")
       }
     }
@@ -173,8 +195,8 @@ class ScoverageInstrumentationComponent(val global: Global, extraAfterPhase: Opt
         reporter.echo(s"Will write measurement data to [${ options.dataDir }]")
       }
       else {
-        reporter.echo(s"Will write measurements data to the directory specified by environment" +
-          s" variable SCOVERAGE_MEASUREMENT_PATH at runtime.")
+        reporter.echo(s"Will write measurements data to the directory specified by system" +
+          s" variable scoverage_measurement_path at runtime.")
       }
     }
   }
@@ -199,49 +221,41 @@ class ScoverageInstrumentationComponent(val global: Global, extraAfterPhase: Opt
     def safeLine(tree: Tree): Int = if (tree.pos.isDefined) tree.pos.line else -1
     def safeSource(tree: Tree): Option[SourceFile] = if (tree.pos.isDefined) Some(tree.pos.source) else None
 
-    def invokeCall(id: Int): Tree = {
+    var termName: String = ""
+    var secondArg: String = ""
+    if (options.writeToClasspath){
       /**
-       * We still pass in [options.dataDir] as one of the instruments with
-       * [invokedUseEnvironment] as it helps differentiating the source
-       * files at runtime, i.e helps in creating a unique subdir for each source file.
+       * We pass in [targetId] as one of the instruments with
+       * [invokedUseEnvironment] as it helps in grabbing the "correct" instruments
+       * file from the classpath at runtime. It also helps in
+       * differentiating the targets at runtime, i.e helps in creating a unique subdir for each target.
        */
-      if (options.writeToClasspath){
-        Apply(
+      termName = "invokedWriteToClasspath"
+      secondArg = targetId
+    }
+    else{
+      termName = "invoked"
+      secondArg = options.dataDir
+    }
+
+    def invokeCall(id: Int): Tree = {
+      Apply(
+        Select(
           Select(
-            Select(
-              Ident("scoverage"),
-              newTermName("Invoker")
-            ),
-            newTermName("invokedWriteToClasspath")
+            Ident("scoverage"),
+            newTermName("Invoker")
           ),
-          List(
-            Literal(
-              Constant(id)
-            ),
-            Literal(
-              Constant(options.dataDir)
-            )
+          newTermName(termName)
+        ),
+        List(
+          Literal(
+            Constant(id)
+          ),
+          Literal(
+            Constant(secondArg)
           )
         )
-      }else {
-        Apply(
-          Select(
-            Select(
-              Ident("scoverage"),
-              newTermName("Invoker")
-            ),
-            newTermName("invoked")
-          ),
-          List(
-            Literal(
-              Constant(id)
-            ),
-            Literal(
-              Constant(options.dataDir)
-            )
-          )
-        )
-      }
+      )
     }
 
     override def transform(tree: Tree) = process(tree)

--- a/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
+++ b/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
 import scoverage.Platform.File
 
 /**
- * Verify that [[Invoker.invoked()]] can handle a multi-module project
+ * Verify that [[Invoker.invokedWriteToClasspath()]] works as expected.
  */
 class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
 
@@ -26,7 +26,7 @@ class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
 
     val testIds: Set[Int] = (1 to 10).toSet
 
-    testIds.map { i: Int => Invoker.invokedUseEnvironment(i, instrumentsDir(i % 2).toString)}
+    testIds.map { i: Int => Invoker.invokedWriteToClasspath(i, instrumentsDir(i % 2).toString)}
 
     // Verify measurements went to correct directory under the environment variable.
     val dir0 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.md5HashString(instrumentsDir(0).toString)}"
@@ -38,7 +38,7 @@ class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
     val dir1 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.md5HashString(instrumentsDir(1).toString)}"
     val measurementFiles4 = Invoker.findMeasurementFiles(dir1)
     val idsFromFile4 = Invoker.invoked(measurementFiles4.toIndexedSeq)
-    idsFromFile3 === testIds.filter { i: Int => i % 2 == 1}
+    idsFromFile4 === testIds.filter { i: Int => i % 2 == 1}
 
     // Verify that coverage files have been copied correctly.
     assert(Files.exists(Paths.get(s"$dir0/scoverage.coverage")))

--- a/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
+++ b/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
@@ -29,16 +29,16 @@ class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
     testIds.map { i: Int => Invoker.invokedWriteToClasspath(i, instrumentsDir(i % 2).toString)}
 
     // Verify measurements went to correct directory under the environment variable.
-    val dir0 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.md5HashString(instrumentsDir(0).toString)}"
+    val dir0 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.safe_name(instrumentsDir(0).toString)}"
     val measurementFiles3 = Invoker.findMeasurementFiles(dir0)
     val idsFromFile3 = Invoker.invoked(measurementFiles3.toIndexedSeq)
-    idsFromFile3 === testIds.filter { i: Int => i % 2 == 0}
+    assert (idsFromFile3 == testIds.filter { i: Int => i % 2 == 0})
 
 
-    val dir1 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.md5HashString(instrumentsDir(1).toString)}"
+    val dir1 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.safe_name(instrumentsDir(1).toString)}"
     val measurementFiles4 = Invoker.findMeasurementFiles(dir1)
     val idsFromFile4 = Invoker.invoked(measurementFiles4.toIndexedSeq)
-    idsFromFile4 === testIds.filter { i: Int => i % 2 == 1}
+    assert (idsFromFile4 == testIds.filter { i: Int => i % 2 == 1})
 
     // Verify that coverage files have been copied correctly.
     assert(Files.exists(Paths.get(s"$dir0/scoverage.coverage")))
@@ -61,7 +61,7 @@ class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
   private def deleteMeasurementFolders(): Unit = {
     val d = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}"
     instrumentsDir.foreach (i => {
-      val f = new File(s"$d/${Invoker.md5HashString(i.toString)}")
+      val f = new File(s"$d/${Invoker.safe_name(i.toString)}")
       if (f.isDirectory)
         f.listFiles().foreach(_.delete())
     })

--- a/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
+++ b/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
@@ -1,6 +1,5 @@
 package scoverage
 
-import java.nio.file.{Files, Paths}
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import scoverage.Platform.File
 
@@ -10,58 +9,47 @@ import scoverage.Platform.File
 class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
 
 
-  val instrumentsDir = Array(
-    new File("target/invoker-test.instrument0"),
-    new File("target/invoker-test.instrument1")
+  val targetIds = Array(
+    new File("target_id_0"),
+    new File("target_id_1")
   )
 
   before {
-    deleteInstrumentFiles()
-    instrumentsDir.foreach(_.mkdirs())
-    createNewInstruments()
+    System.setProperty("scoverage_measurement_path","scoverage_java_prop")
   }
 
-  test("calling Invoker.invokedUseEnvironments puts the data on env var SCOVERAGE_MEASUREMENT_PATH" +
-    " and copies coverage files from instruments directory.") {
+  test("calling Invoker.invokedUseEnvironments puts the data on sys property scoverage_measurement_path") {
 
     val testIds: Set[Int] = (1 to 10).toSet
 
-    testIds.map { i: Int => Invoker.invokedWriteToClasspath(i, instrumentsDir(i % 2).toString)}
+    testIds.map { i: Int => Invoker.invokedWriteToClasspath(i, targetIds(i % 2).toString)}
 
-    // Verify measurements went to correct directory under the environment variable.
-    val dir0 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.safe_name(instrumentsDir(0).toString)}"
+    // Verify that [Invoker.dataDir] has been set correctly.
+    assert(Invoker.dataDir == System.getProperty("scoverage_measurement_path"))
+
+    // Verify measurements went to correct directory under the system property.
+    val dir0 = s"${Invoker.dataDir}/${targetIds(0).toString}"
     val measurementFiles3 = Invoker.findMeasurementFiles(dir0)
     val idsFromFile3 = Invoker.invoked(measurementFiles3.toIndexedSeq)
     assert (idsFromFile3 == testIds.filter { i: Int => i % 2 == 0})
 
 
-    val dir1 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.safe_name(instrumentsDir(1).toString)}"
+    val dir1 = s"${Invoker.dataDir}/${targetIds(1).toString}"
     val measurementFiles4 = Invoker.findMeasurementFiles(dir1)
     val idsFromFile4 = Invoker.invoked(measurementFiles4.toIndexedSeq)
     assert (idsFromFile4 == testIds.filter { i: Int => i % 2 == 1})
 
-    // Verify that coverage files have been copied correctly.
-    assert(Files.exists(Paths.get(s"$dir0/scoverage.coverage")))
-    assert(Files.exists(Paths.get(s"$dir1/scoverage.coverage")))
   }
 
   after {
-    deleteInstrumentFiles()
-    instrumentsDir.foreach(_.delete())
     deleteMeasurementFolders()
   }
 
-  private def deleteInstrumentFiles(): Unit = {
-    instrumentsDir.foreach((md) => {
-      if (md.isDirectory)
-        md.listFiles().foreach(_.delete())
-    })
-  }
 
   private def deleteMeasurementFolders(): Unit = {
-    val d = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}"
-    instrumentsDir.foreach (i => {
-      val f = new File(s"$d/${Invoker.safe_name(i.toString)}")
+    val d = s"${Invoker.dataDir}"
+    targetIds.foreach (i => {
+      val f = new File(s"$d/${i.toString}")
       if (f.isDirectory)
         f.listFiles().foreach(_.delete())
     })
@@ -72,9 +60,5 @@ class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
     f2.delete()
   }
 
-  private def createNewInstruments(): Unit = {
-    new File("target/invoker-test.instrument0/scoverage.coverage").createNewFile()
-    new File("target/invoker-test.instrument1/scoverage.coverage").createNewFile()
-  }
 
 }

--- a/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
+++ b/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerUseEnvironmentTest.scala
@@ -1,0 +1,80 @@
+package scoverage
+
+import java.nio.file.{Files, Paths}
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import scoverage.Platform.File
+
+/**
+ * Verify that [[Invoker.invoked()]] can handle a multi-module project
+ */
+class InvokerUseEnvironmentTest extends FunSuite with BeforeAndAfter {
+
+
+  val instrumentsDir = Array(
+    new File("target/invoker-test.instrument0"),
+    new File("target/invoker-test.instrument1")
+  )
+
+  before {
+    deleteInstrumentFiles()
+    instrumentsDir.foreach(_.mkdirs())
+    createNewInstruments()
+  }
+
+  test("calling Invoker.invokedUseEnvironments puts the data on env var SCOVERAGE_MEASUREMENT_PATH" +
+    " and copies coverage files from instruments directory.") {
+
+    val testIds: Set[Int] = (1 to 10).toSet
+
+    testIds.map { i: Int => Invoker.invokedUseEnvironment(i, instrumentsDir(i % 2).toString)}
+
+    // Verify measurements went to correct directory under the environment variable.
+    val dir0 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.md5HashString(instrumentsDir(0).toString)}"
+    val measurementFiles3 = Invoker.findMeasurementFiles(dir0)
+    val idsFromFile3 = Invoker.invoked(measurementFiles3.toIndexedSeq)
+    idsFromFile3 === testIds.filter { i: Int => i % 2 == 0}
+
+
+    val dir1 = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}/${Invoker.md5HashString(instrumentsDir(1).toString)}"
+    val measurementFiles4 = Invoker.findMeasurementFiles(dir1)
+    val idsFromFile4 = Invoker.invoked(measurementFiles4.toIndexedSeq)
+    idsFromFile3 === testIds.filter { i: Int => i % 2 == 1}
+
+    // Verify that coverage files have been copied correctly.
+    assert(Files.exists(Paths.get(s"$dir0/scoverage.coverage")))
+    assert(Files.exists(Paths.get(s"$dir1/scoverage.coverage")))
+  }
+
+  after {
+    deleteInstrumentFiles()
+    instrumentsDir.foreach(_.delete())
+    deleteMeasurementFolders()
+  }
+
+  private def deleteInstrumentFiles(): Unit = {
+    instrumentsDir.foreach((md) => {
+      if (md.isDirectory)
+        md.listFiles().foreach(_.delete())
+    })
+  }
+
+  private def deleteMeasurementFolders(): Unit = {
+    val d = s"${System.getenv("SCOVERAGE_MEASUREMENT_PATH")}"
+    instrumentsDir.foreach (i => {
+      val f = new File(s"$d/${Invoker.md5HashString(i.toString)}")
+      if (f.isDirectory)
+        f.listFiles().foreach(_.delete())
+    })
+
+    val f2 = new File(d)
+    if(f2.isDirectory)
+      f2.listFiles().foreach(_.delete())
+    f2.delete()
+  }
+
+  private def createNewInstruments(): Unit = {
+    new File("target/invoker-test.instrument0/scoverage.coverage").createNewFile()
+    new File("target/invoker-test.instrument1/scoverage.coverage").createNewFile()
+  }
+
+}

--- a/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
+++ b/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
@@ -9,15 +9,21 @@ object Invoker {
 
   private val MeasurementsPrefix = "scoverage.measurements."
   private val CoverageFileName = "scoverage.coverage"
+  private val ClasspathSubdir = "META-INF/scoverage"
+
   private val threadFiles = new ThreadLocal[mutable.HashMap[String, FileWriter]]
   // For each data directory we maintain a thread-safe set tracking the ids that we've already
   // seen and recorded. We're using a map as a set, so we only care about its keys and can ignore
   // its values.
   private val dataDirToIds = ThreadSafeMap.empty[String, ThreadSafeMap[Int, Any]]
-  // environment variable from where we get the path to output dir for measurements
-  private val measurementFileEnv = "SCOVERAGE_MEASUREMENT_PATH"
-  // Used to store measurements files in case environment option is not set
+  // System property from where we get the path to output dir for measurements
+  private val measurementFileEnv = "scoverage_measurement_path"
+  // Used to store measurements files in case system property is not set
   private val subdir = "scoverageMeasurements"
+
+  // Get the output data directory from the System property [scoverage_measurement_path]
+  // variable or write to a subdir.
+  lazy val dataDir: String = System.getProperty(measurementFileEnv, subdir)
 
 
   /**
@@ -67,75 +73,40 @@ object Invoker {
   }
 
   /**
-   * We record that the given id has been invoked by appending its id to the coverage
-   * data file.
-   *
-   * This will happen concurrently on as many threads as the application is using,
-   * so we use one file per thread, named for the thread id.
-   *
-   * This method is not thread-safe if the threads are in different JVMs, because
-   * the thread IDs may collide.
-   * You may not use `scoverage` on multiple processes in parallel without risking
-   * corruption of the measurement file.
-   *
-   * Same method as above but added additional features to make it work with
-   * https://github.com/scoverage/scalac-scoverage-plugin/issues/265. Typically, we clean the dataDir
-   * and add coverage instruments to the measurement file at runtime rather than compile time. This is
-   * needed as the runtime process may be running on a different host than the compile time one.
-   * However, since the instruments are on the classpath, we can retrieve the instruments from different hosts.
+   * Invokes above method after adding additional features to make it work with
+   * https://github.com/scoverage/scalac-scoverage-plugin/issues/265. Typically, we
+   * add coverage instrument files [scoverage.coverage] along with the measurement files at runtime
+   * rather than compile time. This is needed as the runtime process may be running
+   * on a different host than the compile time one.
+   * However, since the instrument files are on the classpath, we can retrieve the instruments from different hosts.
    *
    * @param id the id of the statement that was invoked
-   * @param instrumentsDir the directory where the instrument data is held and needs to be copied from
+   * @param targetId targetId helps in grabbing the "correct" instrument file from cp that corresponds
+   *                 to the measurement file written during this invocation.
    */
-  def invokedWriteToClasspath(id: Int, instrumentsDir: String): Unit = {
-    // Get the output data directory from the environment variable or write to a subdir.
-    var dataDir: String = ""
-    sys.env.get(measurementFileEnv) match {
-      case Some(d) => dataDir = d
-      case None => dataDir = subdir
-    }
-
+  def invokedWriteToClasspath(id: Int, targetId: String): Unit = {
     // Adding subdir to the basedir. This is because every
-    // instrumented binary has a coverage object for which measurements will be generated
-    // and it is possible that a test file tests multiple instrumented binaries. Thus, to
-    // segregate reports for each source file, we need this hash. This was not an issue with
-    // previous version as then we explicitly specified a different [dataDir] each time.
-    dataDir += s"/${safe_name(instrumentsDir)}"
-    // [sam] we can do this simple check to save writing out to a file.
-    // This won't work across JVMs but since there's no harm in writing out the same id multiple
-    // times since for coverage we only care about 1 or more, (it just slows things down to
-    // do it more than once), anything we can do to help is good. This helps especially with code
-    // that is executed many times quickly, eg tight loops.
-    if (!dataDirToIds.contains(dataDir)) {
+    // unique target has a instrument file [scoverage.coverage] for which corresponding
+    // measurements [scoverage.measurements] will be generated and it is possible that a
+    // test file tests multiple targets. And thus, multiple measurement files will be generated
+    // which needs to be stored SEPARATELY from each other (but along with THEIR instrument files).
+    // Thus, to segregate (instruments + measurements) for each target, we need this subdir.
+    // This was not an issue with previous version as then we explicitly
+    // specified a different [dataDir] each time we compiled a target.
+    val newDataDir = dataDir + s"/$targetId"
+
+    if (!dataDirToIds.contains(newDataDir)) {
       // Guard against SI-7943: "TrieMap method getOrElseUpdate is not thread-safe".
       dataDirToIds.synchronized {
-        if (!dataDirToIds.contains(dataDir)) {
-          // When code is changed in source file, old measurements present
-          // inside the dataDir can skew the results. Thus, clean the dataDir to remove
-          // old measurements.
-          resetDataDir(dataDir)
+        if (!dataDirToIds.contains(newDataDir)) {
           // copy instruments.
-          if (Files.exists(Paths.get(s"$instrumentsDir/$CoverageFileName"))) {
-            copyCoverageFile(instrumentsDir, dataDir)
-          }
-          dataDirToIds(dataDir) = ThreadSafeMap.empty[Int, Any]
+          new File(newDataDir).mkdirs()
+          copyCoverageFile(targetId, newDataDir)
+          dataDirToIds(newDataDir) = ThreadSafeMap.empty[Int, Any]
         }
       }
     }
-    val ids = dataDirToIds(dataDir)
-    if (!ids.contains(id)) {
-      // Each thread writes to a separate measurement file, to reduce contention
-      // and because file appends via FileWriter are not atomic on Windows.
-      var files = threadFiles.get()
-      if (files == null) {
-        files = mutable.HashMap.empty[String, FileWriter]
-        threadFiles.set(files)
-      }
-      val writer = files.getOrElseUpdate(dataDir, new FileWriter(measurementFile(dataDir), true))
-      writer.append(Integer.toString(id)).append("\n").flush()
-
-      ids.put(id, ())
-    }
+    invoked(id, newDataDir)
   }
 
   def measurementFile(dataDir: File): File = measurementFile(dataDir.getAbsolutePath)
@@ -147,32 +118,23 @@ object Invoker {
   })
 
 
-  def resetDataDir(dataDir: String): Unit = {
-    // Making the directory if it does not exist
-    new File(dataDir).mkdirs()
-
-    // clean the directory
-    findMeasurementFiles(dataDir).foreach(_.delete)
-  }
-
   /**
-   *  Copy coverage file from [src] dir to [dest] dir
-   * @param src directory path for source of coverage sfile
-   * @param dest directory path for destination of coverage file
+   * Copy instruments file from classpath.
+   *
+   * @param targetId targetId helps in grabbing the "correct" instrument file from cp that corresponds
+   *                 to the measurement file written during this invocation.
+   * @param dest     directory path for destination of coverage file
    */
-  def copyCoverageFile(src: String, dest: String) = {
-    Files.copy(
-      Paths.get(s"$src/$CoverageFileName"),
-      Paths.get(s"$dest/$CoverageFileName"),
-      StandardCopyOption.REPLACE_EXISTING
-    )
-  }
+  def copyCoverageFile(targetId: String, dest: String): Unit = {
 
-  def safe_name(str: String): String =  {
-    val pattern = "[^/]+".r
-    val matches = pattern.findAllIn(str).toList
-    val res = matches.mkString(".")
-    res
+    // Getting the instrument file `META-INF/scoverage/< targetId >/scoverage.coverage` from classpath
+    val r = Thread.currentThread.getContextClassLoader.getResourceAsStream(s"$ClasspathSubdir/$targetId/$CoverageFileName")
+
+    // Copying the instruments file to the directory that will contain measurements.
+    if (r != null) {
+      Files.copy(r, Paths.get(s"$dest/$CoverageFileName"), StandardCopyOption.REPLACE_EXISTING)
+      r.close()
+    }
   }
 
   // loads all the invoked statement ids from the given files
@@ -189,4 +151,5 @@ object Invoker {
     }
     acc
   }
+
 }

--- a/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
+++ b/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
@@ -81,7 +81,7 @@ object Invoker {
    * Same method as above but added additional features to make it work with
    * https://github.com/scoverage/scalac-scoverage-plugin/issues/265. Typically, we clean the dataDir
    * and add coverage instruments to the measurement file at runtime rather than compile time. This is
-   * needed as ahe runtime process may be running on a different host than the compile time one.
+   * needed as the runtime process may be running on a different host than the compile time one.
    * However, since the instruments are on the classpath, we can retrieve the instruments from different hosts.
    *
    * @param id the id of the statement that was invoked
@@ -95,7 +95,7 @@ object Invoker {
       case None => dataDir = subdir
     }
 
-    // Generating a hash to add as a subdir to the basedir. This is because every
+    // Adding subdir to the basedir. This is because every
     // instrumented binary has a coverage object for which measurements will be generated
     // and it is possible that a test file tests multiple instrumented binaries. Thus, to
     // segregate reports for each source file, we need this hash. This was not an issue with

--- a/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
+++ b/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
@@ -1,18 +1,24 @@
 package scoverage
 
-import scala.collection.{mutable, Set}
+import scala.collection.{Set, mutable}
+import java.nio.file.{Files, Paths, StandardCopyOption}
 import scoverage.Platform._
 
 /** @author Stephen Samuel */
 object Invoker {
 
   private val MeasurementsPrefix = "scoverage.measurements."
+  private val CoverageFileName = "scoverage.coverage"
   private val threadFiles = new ThreadLocal[mutable.HashMap[String, FileWriter]]
-
   // For each data directory we maintain a thread-safe set tracking the ids that we've already
   // seen and recorded. We're using a map as a set, so we only care about its keys and can ignore
   // its values.
   private val dataDirToIds = ThreadSafeMap.empty[String, ThreadSafeMap[Int, Any]]
+  // environment variable from where we get the path to output dir for measurements
+  private val measurementFileEnv = "SCOVERAGE_MEASUREMENT_PATH"
+  // Used to store measurements files in case environment option is not set
+  private val subdir = "scoverageMeasurements"
+
 
   /**
    * We record that the given id has been invoked by appending its id to the coverage
@@ -30,12 +36,87 @@ object Invoker {
    * @param dataDir the directory where the measurement data is held
    */
   def invoked(id: Int, dataDir: String): Unit = {
+
     // [sam] we can do this simple check to save writing out to a file.
     // This won't work across JVMs but since there's no harm in writing out the same id multiple
     // times since for coverage we only care about 1 or more, (it just slows things down to
     // do it more than once), anything we can do to help is good. This helps especially with code
     // that is executed many times quickly, eg tight loops.
     if (!dataDirToIds.contains(dataDir)) {
+      // Guard against SI-7943: "TrieMap method getOrElseUpdate is not thread-safe".
+      dataDirToIds.synchronized {
+        if (!dataDirToIds.contains(dataDir)) {
+          dataDirToIds(dataDir) = ThreadSafeMap.empty[Int, Any]
+        }
+      }
+    }
+    val ids = dataDirToIds(dataDir)
+    if (!ids.contains(id)) {
+      // Each thread writes to a separate measurement file, to reduce contention
+      // and because file appends via FileWriter are not atomic on Windows.
+      var files = threadFiles.get()
+      if (files == null) {
+        files = mutable.HashMap.empty[String, FileWriter]
+        threadFiles.set(files)
+      }
+      val writer = files.getOrElseUpdate(dataDir, new FileWriter(measurementFile(dataDir), true))
+      writer.append(Integer.toString(id)).append("\n").flush()
+
+      ids.put(id, ())
+    }
+  }
+
+  /**
+   * We record that the given id has been invoked by appending its id to the coverage
+   * data file.
+   *
+   * This will happen concurrently on as many threads as the application is using,
+   * so we use one file per thread, named for the thread id.
+   *
+   * This method is not thread-safe if the threads are in different JVMs, because
+   * the thread IDs may collide.
+   * You may not use `scoverage` on multiple processes in parallel without risking
+   * corruption of the measurement file.
+   *
+   * Same method as above but added additional features to make it work with
+   * https://github.com/scoverage/scalac-scoverage-plugin/issues/265. Typically, we clean the dataDir
+   * and add coverage instruments to the measurement file at runtime rather than compile time. This is
+   * needed as ahe runtime process may be running on a different host than the compile time one.
+   * However, since the instruments are on the classpath, we can retrieve the instruments from different hosts.
+   *
+   * @param id the id of the statement that was invoked
+   * @param instrumentsDir the directory where the instrument data is held and needs to be copied from
+   */
+  def invokedUseEnvironment(id: Int, instrumentsDir: String): Unit = {
+    // Generating a hash to add as a subdir to the basedir. This is because every
+    // instrumented binary has a coverage object for which measurements will be generated
+    // and it is possible that a test file tests multiple instrumented binaries. Thus, to
+    // segregate reports for each source file, we need this hash. This was not an issue with
+    // previous version as then we explicitly specified a different [dataDir] each time.
+    val instrumentHash = md5HashString(instrumentsDir)
+
+    // Get the output data directory from the environment variable or write to a subdir.
+    var dataDir: String = ""
+    sys.env.get(measurementFileEnv) match {
+      case Some(d) => dataDir = d
+      case None => dataDir = subdir
+    }
+
+    dataDir += s"/$instrumentHash"
+    // [sam] we can do this simple check to save writing out to a file.
+    // This won't work across JVMs but since there's no harm in writing out the same id multiple
+    // times since for coverage we only care about 1 or more, (it just slows things down to
+    // do it more than once), anything we can do to help is good. This helps especially with code
+    // that is executed many times quickly, eg tight loops.
+    if (!dataDirToIds.contains(dataDir)) {
+      // When code is changed in source file, old measurements present
+      // inside the dataDir can skew the results. Thus, clean the dataDir to remove
+      // old measurements.
+      resetDataDir(dataDir)
+      // copy instruments.
+      if (Files.exists(Paths.get(s"$instrumentsDir/$CoverageFileName"))) {
+        copyCoverageFile(instrumentsDir, dataDir)
+      }
       // Guard against SI-7943: "TrieMap method getOrElseUpdate is not thread-safe".
       dataDirToIds.synchronized {
         if (!dataDirToIds.contains(dataDir)) {
@@ -66,6 +147,39 @@ object Invoker {
   def findMeasurementFiles(dataDir: File): Array[File] = dataDir.listFiles(new FileFilter {
     override def accept(pathname: File): Boolean = pathname.getName.startsWith(MeasurementsPrefix)
   })
+
+
+  def resetDataDir(dataDir: String): Unit = {
+    // Making the directory if it does not exist
+    new File(dataDir).mkdirs()
+
+    // clean the directory
+    findMeasurementFiles(dataDir).foreach(_.delete)
+  }
+
+  /**
+   *  Copy coverage file from [src] dir to [dest] dir
+   * @param src directory path for source of coverage sfile
+   * @param dest directory path for destination of coverage file
+   */
+  def copyCoverageFile(src: String, dest: String) = {
+    Files.copy(
+      Paths.get(s"$src/$CoverageFileName"),
+      Paths.get(s"$dest/$CoverageFileName"),
+      StandardCopyOption.REPLACE_EXISTING
+    )
+  }
+
+  // used for generating a hash for each instrumentDir.
+  def md5HashString(s: String): String = {
+    import java.security.MessageDigest
+    import java.math.BigInteger
+    val md = MessageDigest.getInstance("MD5")
+    val digest = md.digest(s.getBytes)
+    val bigInt = new BigInteger(1,digest)
+    val hashedString = bigInt.toString(16)
+    hashedString
+  }
 
   // loads all the invoked statement ids from the given files
   def invoked(files: Seq[File]): Set[Int] = {

--- a/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
+++ b/scalac-scoverage-runtime/shared/src/main/scala/scoverage/Invoker.scala
@@ -87,7 +87,7 @@ object Invoker {
    * @param id the id of the statement that was invoked
    * @param instrumentsDir the directory where the instrument data is held and needs to be copied from
    */
-  def invokedUseEnvironment(id: Int, instrumentsDir: String): Unit = {
+  def invokedWriteToClasspath(id: Int, instrumentsDir: String): Unit = {
     // Generating a hash to add as a subdir to the basedir. This is because every
     // instrumented binary has a coverage object for which measurements will be generated
     // and it is possible that a test file tests multiple instrumented binaries. Thus, to
@@ -109,17 +109,17 @@ object Invoker {
     // do it more than once), anything we can do to help is good. This helps especially with code
     // that is executed many times quickly, eg tight loops.
     if (!dataDirToIds.contains(dataDir)) {
-      // When code is changed in source file, old measurements present
-      // inside the dataDir can skew the results. Thus, clean the dataDir to remove
-      // old measurements.
-      resetDataDir(dataDir)
-      // copy instruments.
-      if (Files.exists(Paths.get(s"$instrumentsDir/$CoverageFileName"))) {
-        copyCoverageFile(instrumentsDir, dataDir)
-      }
       // Guard against SI-7943: "TrieMap method getOrElseUpdate is not thread-safe".
       dataDirToIds.synchronized {
         if (!dataDirToIds.contains(dataDir)) {
+          // When code is changed in source file, old measurements present
+          // inside the dataDir can skew the results. Thus, clean the dataDir to remove
+          // old measurements.
+          resetDataDir(dataDir)
+          // copy instruments.
+          if (Files.exists(Paths.get(s"$instrumentsDir/$CoverageFileName"))) {
+            copyCoverageFile(instrumentsDir, dataDir)
+          }
           dataDirToIds(dataDir) = ThreadSafeMap.empty[Int, Any]
         }
       }


### PR DESCRIPTION
I have created a pull request for this [issue](https://github.com/scoverage/scalac-scoverage-plugin/issues/265).  The changes I have made are recommendations given by @stuhood in the comment on the issue.

in Plugin.scala, added an additional option `writeToClasspath` that, if set to true, stores the instruments to the classpath and invokes `Invoker.invokedWriteToClasspath` in `Invoker.scala` at runtime. 

In Invoker.scala, creating a new directory from the system option `scoverage_measurement_path` and copying the instruments there along with storing the measurements. If the system var is not set, it creates a subdirectory in the cwd.

If the option is not set (or is set to False), scoverage works the usual way.

Added a test for `invokedUseEnvironment`: `sbt "testOnly scoverage.InvokerUseEnvironmentTest"`