### PR TITLE
Add mill plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ project you will need to use one of the build plugins:
 * [sbt-scoverage](https://github.com/scoverage/sbt-scoverage)
 * [gradle-scoverage](https://github.com/scoverage/gradle-scoverage)
 * [sbt-coveralls](https://github.com/scoverage/sbt-coveralls)
+* [mill-contrib-scoverage](https://www.lihaoyi.com/mill/page/contrib-modules.html#scoverage)
 * Upload report to [Codecov](https://codecov.io): [Example Scala Repository](https://github.com/codecov/example-scala)
 
 Scoverage support is available for the following tools:


### PR DESCRIPTION
Mill users recently gained the ability to use scoverage in their builds.