### PR TITLE
converting source path from absolute to relative

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/Serializer.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/Serializer.scala
@@ -26,8 +26,9 @@ object Serializer {
     // instead of the canonical path. This is required to make it work with
     // remoting or in a distributed environment.
     def getRelativePath(filePath: String): String = {
-      val base = new File(".").getCanonicalPath + File.separator
-      filePath.replace(base, "")
+      val base = new File(".").getCanonicalFile.toPath
+      val relPath = base.relativize(new File(filePath).getCanonicalFile.toPath)
+      relPath.toString
     }
 
     def writeHeader(writer: Writer): Unit = {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
@@ -1,6 +1,7 @@
 package scoverage
 
 import java.io.StringWriter
+import java.io.File
 
 import org.scalatest.{OneInstancePerTest, FunSuite}
 
@@ -97,7 +98,7 @@ class SerializerTest extends FunSuite with OneInstancePerTest {
         |\f
         |""".stripMargin.split("\n").iterator
     val statements = List(Statement(
-      Location("org.scoverage", "test", "org.scoverage.test", ClassType.Trait, "mymethod", "mypath"),
+      Location("org.scoverage", "test", "org.scoverage.test", ClassType.Trait, "mymethod", new File("mypath").getCanonicalPath),
       14, 100, 200, 4, "def test : String", "test", "DefDef", true, 1
     ))
     val coverage = Serializer.deserialize(input)

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
@@ -104,4 +104,102 @@ class SerializerTest extends FunSuite with OneInstancePerTest {
     val coverage = Serializer.deserialize(input)
     assert(statements === coverage.statements.toList)
   }
+
+  test("coverage should serialize sourcePath relatively") {
+    val coverage = Coverage()
+    coverage.add(
+      Statement(
+        Location("org.scoverage", "test", "org.scoverage.test", ClassType.Trait, "mymethod", new File(".").getCanonicalPath + File.separator + "mypath"),
+        14, 100, 200, 4, "def test : String", "test", "DefDef", true, 1
+      )
+    )
+    val expected = s"""# Coverage data, format version: 2.0
+                      |# Statement data:
+                      |# - id
+                      |# - source path
+                      |# - package name
+                      |# - class name
+                      |# - class type (Class, Object or Trait)
+                      |# - full class name
+                      |# - method name
+                      |# - start offset
+                      |# - end offset
+                      |# - line number
+                      |# - symbol name
+                      |# - tree name
+                      |# - is branch
+                      |# - invocations count
+                      |# - is ignored
+                      |# - description (can be multi-line)
+                      |# '\f' sign
+                      |# ------------------------------------------
+                      |14
+                      |mypath
+                      |org.scoverage
+                      |test
+                      |Trait
+                      |org.scoverage.test
+                      |mymethod
+                      |100
+                      |200
+                      |4
+                      |test
+                      |DefDef
+                      |true
+                      |1
+                      |false
+                      |def test : String
+                      |\f
+                      |""".stripMargin
+    val writer = new StringWriter()//TODO-use UTF-8
+    val actual = Serializer.serialize(coverage, writer)
+    assert(expected === writer.toString)
+  }
+
+  test("coverage should deserialize sourcePath by prefixing cwd") {
+    val input = s"""# Coverage data, format version: 2.0
+                   |# Statement data:
+                   |# - id
+                   |# - source path
+                   |# - package name
+                   |# - class name
+                   |# - class type (Class, Object or Trait)
+                   |# - full class name
+                   |# - method name
+                   |# - start offset
+                   |# - end offset
+                   |# - line number
+                   |# - symbol name
+                   |# - tree name
+                   |# - is branch
+                   |# - invocations count
+                   |# - is ignored
+                   |# - description (can be multi-line)
+                   |# '\f' sign
+                   |# ------------------------------------------
+                   |14
+                   |mypath
+                   |org.scoverage
+                   |test
+                   |Trait
+                   |org.scoverage.test
+                   |mymethod
+                   |100
+                   |200
+                   |4
+                   |test
+                   |DefDef
+                   |true
+                   |1
+                   |false
+                   |def test : String
+                   |\f
+                   |""".stripMargin.split("\n").iterator
+    val statements = List(Statement(
+      Location("org.scoverage", "test", "org.scoverage.test", ClassType.Trait, "mymethod", new File(".").getCanonicalPath + File.separator + "mypath"),
+      14, 100, 200, 4, "def test : String", "test", "DefDef", true, 1
+    ))
+    val coverage = Serializer.deserialize(input)
+    assert(statements === coverage.statements.toList)
+  }
 }


### PR DESCRIPTION
Necessary for #265 :
Currently, at compile time, scoverage stores (as a string) the conical sourcePath (path for the source file) for a statement inside the instrument file `scoverage.coverage`. This string is then again required during report generation to get the source file in `ScoverageHtmlWriter` . This breaks in a distributed environment where report generation is happening on a different machine and is unable to locate the source file due to the absolute path. 

The current fix makes the path relative when storing and turns it back to a conical one (w.r.t cwd) on retrieving. Thanks