### PR TITLE
add a new html writer constructor which is easily called from Groovy

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/ScoverageHtmlWriter.scala
@@ -10,6 +10,11 @@ import scala.xml.Node
 /** @author Stephen Samuel */
 class ScoverageHtmlWriter(sourceDirectories: Seq[File], outputDir: File, sourceEncoding: Option[String]) extends BaseReportWriter(sourceDirectories, outputDir) {
 
+  // to be used by gradle-scoverage plugin
+  def this (sourceDirectories: Array[File], outputDir: File, sourceEncoding: Option[String]) {
+    this (sourceDirectories.toSeq, outputDir, sourceEncoding)
+  }
+
   // for backward compatibility only
   def this (sourceDirectories: Seq[File], outputDir: File) {
     this(sourceDirectories, outputDir, None);


### PR DESCRIPTION
This PR aims to simplify things by providing an API that can be accessed without using the Scala collection converters