### PR TITLE
Bump sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8


### PR DESCRIPTION
Bump sbt version to avoid java.io.IOError: java.lang.RuntimeException: /packages cannot be represented as URI