### PR TITLE
Update sbt-pgp to fix build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbt._
 import sbt.Keys._
 import sbtrelease.ReleasePlugin.autoImport._
-import com.typesafe.sbt.pgp.PgpKeys
 import sbtcrossproject.CrossProject
 import sbtcrossproject.CrossType
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 


### PR DESCRIPTION
This PR fixes the following error:

```
..../IdeaProjects/scalac-scoverage-plugin/build.sbt:4: error: object sbt is not a member of package com.typesafe
import com.typesafe.sbt.pgp.PgpKeys
                    ^
[error] sbt.compiler.EvalException: Type error in expression
[error] Use 'last' for the full log.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? 
```


Note)
- `import` is removed since it seems auto-imported.
- the package name is changed in https://github.com/sbt/sbt-pgp/releases/tag/v2.0.0
