### PR TITLE
Don't do a fully binary cross of runtime, only the compiler plugin

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.5.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.2-SNAPSHOT"
+version in ThisBuild := "1.4.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.2"
+version in ThisBuild := "1.4.3-SNAPSHOT"


### PR DESCRIPTION
~Looking back at
https://github.com/scoverage/scalac-scoverage-plugin/commit/ac3db322c54dee18c967764d95f9904ff6d7e89f,
I'm not actually 100% sure this was accurate. While we do need to do a
fully binary publish of the actual compiler plugin, doing a full cross
of the runtime artifact causes some issues. Mainly I just don't believe
it's needed, but also then when publishing for other platforms, there is
odd behavior where you no longer get the sjs prefix that you'd want in
your artifacts published for JS. This change updates a few of the sbt
dependencies, moves to the unified slash syntax, and only applies the
full cross settings to the actual compiler plugin, not the runtime
artifact.~

EDIT: See below

@blast-hardcheese Are you able to take a look at this since you originally made these changes.

This should fix the issue I mentioned having in #305 
