### PR TITLE
Add support back in for 2.12.9 and 2.12.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
             { version: '2.12.12' },
             { version: '2.12.11' },
             { version: '2.12.10' },
+            { version: '2.12.9' },
+            { version: '2.12.8' },
             { version: '2.13.5' },
             { version: '2.13.4' },
             { version: '2.13.3' },

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
             { version: '2.12.12' },
             { version: '2.12.11' },
             { version: '2.12.10' },
+            { version: '2.12.9' },
+            { version: '2.12.8' },
             { version: '2.13.5' },
             { version: '2.13.4' },
             { version: '2.13.3' },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
             { version: '2.12.12' },
             { version: '2.12.11' },
             { version: '2.12.10' },
+            { version: '2.12.9' },
+            { version: '2.12.8' },
             { version: '2.13.5' },
             { version: '2.13.4' },
             { version: '2.13.3' },

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ To see scoverage in action check out the [samples](https://github.com/scoverage/
 
 ### Release History
 
+##### 28th April 2021 - 1.4.3
+
+* Added Scala 2.12.13+, 2.13.5+ support
+* All versions are now cross built with the full scala version (instead of binary only)
+
 ##### 12th June 2019 - 1.4.0
 
 * Added Scala 2.13 support

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbtcrossproject.CrossType
 val Org = "org.scoverage"
 val ScalatestVersion = "3.1.1"
 
-val bin212 = Seq("2.12.13", "2.12.12", "2.12.11", "2.12.10")
+val bin212 = Seq("2.12.13", "2.12.12", "2.12.11", "2.12.10", "2.12.9", "2.12.8")
 val bin213 = Seq("2.13.5", "2.13.4", "2.13.3", "2.13.2", "2.13.1", "2.13.0")
 
 val appSettings = Seq(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.3-SNAPSHOT"
+version in ThisBuild := "1.4.4-SNAPSHOT"


### PR DESCRIPTION
This seems to be a freebie and was probably not included before because there was an assumption that it wasn't needed. However for some older mill testing 2.12.8 is still desired.

FYI @lefou