### PR TITLE
Correct build dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtcrossproject.CrossProject
 import sbtcrossproject.CrossType
 
-def localSnapshotVersion = "1.4.5-SNAPSHOT"
+def localSnapshotVersion = "1.4.6-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 val scalatestVersion = "3.2.8"
@@ -68,18 +68,14 @@ lazy val runtime = CrossProject(
   .settings(
     name := "scalac-scoverage-runtime",
     crossTarget := target.value / s"scala-${scalaVersion.value}",
-    crossVersion := CrossVersion.full,
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % scalatestVersion % Test,
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value % Compile
+      "org.scalatest" %%% "scalatest" % scalatestVersion % Test
     )
   )
   .jvmSettings(
     Test / fork := true
   )
   .jsSettings(
-    crossVersion := CrossVersion
-      .fullWith("sjs" + scalaJSVersion.take(1) + "_", ""),
     scalaJSStage := FastOptStage
   )
 
@@ -96,7 +92,7 @@ lazy val plugin =
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
         "org.scalatest" %% "scalatest" % scalatestVersion % Test,
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Compile
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided
       )
     )
     .settings(


### PR DESCRIPTION
This makes a few small changes:
1. I'm pretty sure the scala-compiler for the actual plugin can just
   have a Provided configuration. I don't believe we actually need to package it
   up seeing that it should always be there.
2. Secondly, I mistakenly added the scala-compiler as a dependency to
   the runtime artifact when it indeed should not be. When I refactored
   the build, it came along, and should have not. If you look back
   you'll notice that it wasn't in 1.4.1
3. When the change was made to start doing a full cross publish in this
       commit: https://github.com/scoverage/scalac-scoverage-plugin/commit/ac3db322c54dee18c967764d95f9904ff6d7e89f
       it was added for both the compiler plugin and the actual runtime.
       Looking through things and testing locally with the sbt plugin, I
       don't see a reason why the runtime needs to actually be crossed fully
       like the actual plugin. This removes the crossVersion full from the
       runtime.