### PR TITLE
Bump scalafmt to 3.0.3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,6 @@
-version = "2.7.5"
+version = "3.0.3"
 project.git = true
+runner.dialect = "scala213"
 assumeStandardLibraryStripMargin = true
 xmlLiterals.assumeFormatted = true
+docstrings.wrap = no


### PR DESCRIPTION
Add in `docstrings.wrap = no` to ensure there isn't a bunch
of wrapping in docstrings where we may not want it. Normally I'd
want this, but it needlessly bumps the text down a line