### PR TITLE
Remove support for 2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,12 @@ jobs:
         os: [ 'ubuntu-latest', 'windows-latest' ]
         java: [ '8', '11' ]
         scala: [
-            { version: '2.11.12' },
             { version: '2.12.15' },
             { version: '2.12.14' },
             { version: '2.12.13' },
-            { version: '2.12.12' },
-            { version: '2.12.11' },
-            { version: '2.12.10' },
-            { version: '2.12.9' },
-            { version: '2.12.8' },
             { version: '2.13.6' },
             { version: '2.13.5' },
-            { version: '2.13.4' },
-            { version: '2.13.3' },
-            { version: '2.13.2' },
-            { version: '2.13.1' },
-            { version: '2.13.0' }
+            { version: '2.13.4' }
           ]
     steps:
       - name: checkout the repo

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ import sbtcrossproject.CrossType
 val scalatestVersion = "3.2.10"
 val scalametaVersion = "4.4.28"
 val defaultScala213 = "2.13.6"
-val bin211 = Seq("2.11.12")
 val bin212 =
   Seq(
     "2.12.15",
@@ -76,7 +75,7 @@ lazy val sharedSettings = List(
       scalacOptions.value
     }
   },
-  crossScalaVersions := bin211 ++ bin212 ++ bin213
+  crossScalaVersions := bin212 ++ bin213
 )
 
 lazy val root = Project("scalac-scoverage", file("."))


### PR DESCRIPTION
Also simplify the testing matrix. We will still publish for those
old versions, but it's a bit crazy to have a matrix with 60 some builds