### PR TITLE
Bump version of scala-xml to 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val plugin =
       crossTarget := target.value / s"scala-${scalaVersion.value}",
       crossVersion := CrossVersion.full,
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
+        "org.scala-lang.modules" %% "scala-xml" % "2.0.0",
         "org.scalatest" %% "scalatest" % scalatestVersion % Test,
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided
       ),

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
@@ -3,8 +3,11 @@ package scoverage
 import java.io.File
 import java.util.UUID
 import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.parsers.SAXParserFactory
 
+import scala.xml.Elem
 import scala.xml.XML
+import scala.xml.factory.XMLLoader
 
 import org.scalatest.BeforeAndAfter
 import org.scalatest.OneInstancePerTest
@@ -314,7 +317,17 @@ class CoberturaXmlWriterTest
     val writer = new CoberturaXmlWriter(sourceRoot, dir)
     writer.write(coverage)
 
-    val xml = XML.loadFile(fileIn(dir))
+    // Needed to acount for https://github.com/scala/scala-xml/pull/177
+    val customXML: XMLLoader[Elem] = XML.withSAXParser {
+      val factory = SAXParserFactory.newInstance()
+      factory.setFeature(
+        "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+        false
+      )
+      factory.newSAXParser()
+    }
+
+    val xml = customXML.loadFile(fileIn(dir))
 
     assert((xml \\ "coverage" \ "@line-rate").text === "0.33", "line-rate")
     assert((xml \\ "coverage" \ "@branch-rate").text === "0.50", "branch-rate")


### PR DESCRIPTION
Since we are no longer supporting 2.11 (#368), we can safely bump this without worry in V2.