### PR TITLE
Convert sourcepath to relative.

### DIFF
--- a/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
+++ b/scalac-scoverage-plugin/src/main/scala/scoverage/report/CoverageAggregator.scala
@@ -8,34 +8,32 @@ import scoverage.Serializer
 
 object CoverageAggregator {
 
-  @deprecated("1.4.0", "Used only by gradle-scoverage plugin")
-  def aggregate(baseDir: File, clean: Boolean): Option[Coverage] = {
-    aggregate(IOUtils.scoverageDataDirsSearch(baseDir))
-  }
-
   // to be used by gradle-scoverage plugin
-  def aggregate(dataDirs: Array[File]): Option[Coverage] = aggregate(
-    dataDirs.toSeq
-  )
+  def aggregate(dataDirs: Array[File], sourceRoot: File): Option[Coverage] =
+    aggregate(
+      dataDirs.toSeq,
+      sourceRoot
+    )
 
-  def aggregate(dataDirs: Seq[File]): Option[Coverage] = {
+  def aggregate(dataDirs: Seq[File], sourceRoot: File): Option[Coverage] = {
     println(
       s"[info] Found ${dataDirs.size} subproject scoverage data directories [${dataDirs.mkString(",")}]"
     )
     if (dataDirs.size > 0) {
-      Some(aggregatedCoverage(dataDirs))
+      Some(aggregatedCoverage(dataDirs, sourceRoot))
     } else {
       None
     }
   }
 
-  def aggregatedCoverage(dataDirs: Seq[File]): Coverage = {
+  def aggregatedCoverage(dataDirs: Seq[File], sourceRoot: File): Coverage = {
     var id = 0
     val coverage = Coverage()
     dataDirs foreach { dataDir =>
       val coverageFile: File = Serializer.coverageFile(dataDir)
       if (coverageFile.exists) {
-        val subcoverage: Coverage = Serializer.deserialize(coverageFile)
+        val subcoverage: Coverage =
+          Serializer.deserialize(coverageFile, sourceRoot)
         val measurementFiles: Array[File] =
           IOUtils.findMeasurementFiles(dataDir)
         val measurements = IOUtils.invoked(measurementFiles.toIndexedSeq)

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageAggregatorTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageAggregatorTest.scala
@@ -11,9 +11,9 @@ import scoverage.report.CoverageAggregator
 class CoverageAggregatorTest extends AnyFreeSpec with Matchers {
 
   // Let current directory be our source root
-  private val sourceRoot = new File(".")
+  private val sourceRoot = new File(".").getCanonicalPath()
   private def canonicalPath(fileName: String) =
-    new File(sourceRoot, fileName).getCanonicalPath
+    new File(sourceRoot, fileName).getCanonicalPath()
 
   "coverage aggregator" - {
     "should merge coverage objects with same id" in {
@@ -35,7 +35,11 @@ class CoverageAggregatorTest extends AnyFreeSpec with Matchers {
       coverage1.add(cov1Stmt2.copy(count = 0))
       val dir1 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
       dir1.mkdir()
-      Serializer.serialize(coverage1, Serializer.coverageFile(dir1))
+      Serializer.serialize(
+        coverage1,
+        Serializer.coverageFile(dir1),
+        new File(sourceRoot)
+      )
       val measurementsFile1 =
         new File(dir1, s"${Constants.MeasurementsPrefix}1")
       val measurementsFile1Writer = new FileWriter(measurementsFile1)
@@ -47,7 +51,11 @@ class CoverageAggregatorTest extends AnyFreeSpec with Matchers {
       coverage2.add(cov2Stmt1)
       val dir2 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
       dir2.mkdir()
-      Serializer.serialize(coverage2, Serializer.coverageFile(dir2))
+      Serializer.serialize(
+        coverage2,
+        Serializer.coverageFile(dir2),
+        new File(sourceRoot)
+      )
 
       val cov3Stmt1 =
         Statement(location, 2, 14, 1515, 544, "", "", "", false, 1)
@@ -55,7 +63,11 @@ class CoverageAggregatorTest extends AnyFreeSpec with Matchers {
       coverage3.add(cov3Stmt1.copy(count = 0))
       val dir3 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
       dir3.mkdir()
-      Serializer.serialize(coverage3, Serializer.coverageFile(dir3))
+      Serializer.serialize(
+        coverage3,
+        Serializer.coverageFile(dir3),
+        new File(sourceRoot)
+      )
       val measurementsFile3 =
         new File(dir3, s"${Constants.MeasurementsPrefix}1")
       val measurementsFile3Writer = new FileWriter(measurementsFile3)
@@ -63,7 +75,10 @@ class CoverageAggregatorTest extends AnyFreeSpec with Matchers {
       measurementsFile3Writer.close()
 
       val aggregated =
-        CoverageAggregator.aggregatedCoverage(Seq(dir1, dir2, dir3))
+        CoverageAggregator.aggregatedCoverage(
+          Seq(dir1, dir2, dir3),
+          new File(sourceRoot)
+        )
       aggregated.statements.toSet.size shouldBe 4
       aggregated.statements.map(_.copy(id = 0)).toSet shouldBe
         Set(cov1Stmt1, cov1Stmt2, cov2Stmt1, cov3Stmt1).map(_.copy(id = 0))

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -119,6 +119,7 @@ class ScoverageCompiler(
 
   val instrumentationComponent =
     new ScoverageInstrumentationComponent(this, None, None)
+
   instrumentationComponent.setOptions(new ScoverageOptions())
   val testStore = new ScoverageTestStoreComponent(this)
   val validator = new PositionValidator(this)

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
@@ -1,11 +1,13 @@
 package scoverage
 
+import java.io.File
 import java.io.StringWriter
 
 import org.scalatest.OneInstancePerTest
 import org.scalatest.funsuite.AnyFunSuite
 
 class SerializerTest extends AnyFunSuite with OneInstancePerTest {
+  private val sourceRoot = new File(".").getCanonicalFile()
 
   test("coverage should be serializable into plain text") {
     val coverage = Coverage()
@@ -17,7 +19,7 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
           "org.scoverage.test",
           ClassType.Trait,
           "mymethod",
-          "mypath"
+          new File(sourceRoot, "mypath").getAbsolutePath()
         ),
         14,
         100,
@@ -30,88 +32,92 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
         1
       )
     )
-    val expected = s"""# Coverage data, format version: 2.0
-                      |# Statement data:
-                      |# - id
-                      |# - source path
-                      |# - package name
-                      |# - class name
-                      |# - class type (Class, Object or Trait)
-                      |# - full class name
-                      |# - method name
-                      |# - start offset
-                      |# - end offset
-                      |# - line number
-                      |# - symbol name
-                      |# - tree name
-                      |# - is branch
-                      |# - invocations count
-                      |# - is ignored
-                      |# - description (can be multi-line)
-                      |# '\f' sign
-                      |# ------------------------------------------
-                      |14
-                      |mypath
-                      |org.scoverage
-                      |test
-                      |Trait
-                      |org.scoverage.test
-                      |mymethod
-                      |100
-                      |200
-                      |4
-                      |test
-                      |DefDef
-                      |true
-                      |1
-                      |false
-                      |def test : String
-                      |\f
-                      |""".stripMargin.replaceAll("(\r\n)|\n|\r", "\n")
+    val expected =
+      s"""# Coverage data, format version: ${Serializer.coverageDataFormatVersion}
+         |# Statement data:
+         |# - id
+         |# - source path
+         |# - package name
+         |# - class name
+         |# - class type (Class, Object or Trait)
+         |# - full class name
+         |# - method name
+         |# - start offset
+         |# - end offset
+         |# - line number
+         |# - symbol name
+         |# - tree name
+         |# - is branch
+         |# - invocations count
+         |# - is ignored
+         |# - description (can be multi-line)
+         |# '\f' sign
+         |# ------------------------------------------
+         |14
+         |mypath
+         |org.scoverage
+         |test
+         |Trait
+         |org.scoverage.test
+         |mymethod
+         |100
+         |200
+         |4
+         |test
+         |DefDef
+         |true
+         |1
+         |false
+         |def test : String
+         |\f
+         |""".stripMargin
     val writer = new StringWriter() //TODO-use UTF-8
-    val actual = Serializer.serialize(coverage, writer)
+    val actual = Serializer.serialize(coverage, writer, sourceRoot)
     assert(expected === writer.toString)
   }
 
   test("coverage should be deserializable from plain text") {
-    val input = s"""# Coverage data, format version: 2.0
-                   |# Statement data:
-                   |# - id
-                   |# - source path
-                   |# - package name
-                   |# - class name
-                   |# - class type (Class, Object or Trait)
-                   |# - full class name
-                   |# - method name
-                   |# - start offset
-                   |# - end offset
-                   |# - line number
-                   |# - symbol name
-                   |# - tree name
-                   |# - is branch
-                   |# - invocations count
-                   |# - is ignored
-                   |# - description (can be multi-line)
-                   |# '\f' sign
-                   |# ------------------------------------------
-                   |14
-                   |mypath
-                   |org.scoverage
-                   |test
-                   |Trait
-                   |org.scoverage.test
-                   |mymethod
-                   |100
-                   |200
-                   |4
-                   |test
-                   |DefDef
-                   |true
-                   |1
-                   |false
-                   |def test : String
-                   |\f
-                   |""".stripMargin.split("(\r\n)|\n|\r").iterator
+    val input =
+      s"""# Coverage data, format version: ${Serializer.coverageDataFormatVersion}
+         |# Statement data:
+         |# - id
+         |# - source path
+         |# - package name
+         |# - class name
+         |# - class type (Class, Object or Trait)
+         |# - full class name
+         |# - method name
+         |# - start offset
+         |# - end offset
+         |# - line number
+         |# - symbol name
+         |# - tree name
+         |# - is branch
+         |# - invocations count
+         |# - is ignored
+         |# - description (can be multi-line)
+         |# '\f' sign
+         |# ------------------------------------------
+         |14
+         |mypath
+         |org.scoverage
+         |test
+         |Trait
+         |org.scoverage.test
+         |mymethod
+         |100
+         |200
+         |4
+         |test
+         |DefDef
+         |true
+         |1
+         |false
+         |def test : String
+         |\f
+         |""".stripMargin
+        .split(System.lineSeparator())
+        .iterator
     val statements = List(
       Statement(
         Location(
@@ -120,7 +126,7 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
           "org.scoverage.test",
           ClassType.Trait,
           "mymethod",
-          "mypath"
+          new File(sourceRoot, "mypath").getAbsolutePath()
         ),
         14,
         100,
@@ -133,7 +139,138 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
         1
       )
     )
-    val coverage = Serializer.deserialize(input)
+    val coverage = Serializer.deserialize(input, sourceRoot)
+    assert(statements === coverage.statements.toList)
+  }
+  test("coverage should serialize sourcePath relatively") {
+    val coverage = Coverage()
+    coverage.add(
+      Statement(
+        Location(
+          "org.scoverage",
+          "test",
+          "org.scoverage.test",
+          ClassType.Trait,
+          "mymethod",
+          new File(sourceRoot, "mypath").getAbsolutePath()
+        ),
+        14,
+        100,
+        200,
+        4,
+        "def test : String",
+        "test",
+        "DefDef",
+        true,
+        1
+      )
+    )
+    val expected =
+      s"""# Coverage data, format version: ${Serializer.coverageDataFormatVersion}
+         |# Statement data:
+         |# - id
+         |# - source path
+         |# - package name
+         |# - class name
+         |# - class type (Class, Object or Trait)
+         |# - full class name
+         |# - method name
+         |# - start offset
+         |# - end offset
+         |# - line number
+         |# - symbol name
+         |# - tree name
+         |# - is branch
+         |# - invocations count
+         |# - is ignored
+         |# - description (can be multi-line)
+         |# '\f' sign
+         |# ------------------------------------------
+         |14
+         |mypath
+         |org.scoverage
+         |test
+         |Trait
+         |org.scoverage.test
+         |mymethod
+         |100
+         |200
+         |4
+         |test
+         |DefDef
+         |true
+         |1
+         |false
+         |def test : String
+         |\f
+         |""".stripMargin
+    val writer = new StringWriter() //TODO-use UTF-8
+    val actual = Serializer.serialize(coverage, writer, sourceRoot)
+    assert(expected === writer.toString)
+  }
+
+  test("coverage should deserialize sourcePath by prefixing cwd") {
+    val input =
+      s"""# Coverage data, format version: ${Serializer.coverageDataFormatVersion}
+         |# Statement data:
+         |# - id
+         |# - source path
+         |# - package name
+         |# - class name
+         |# - class type (Class, Object or Trait)
+         |# - full class name
+         |# - method name
+         |# - start offset
+         |# - end offset
+         |# - line number
+         |# - symbol name
+         |# - tree name
+         |# - is branch
+         |# - invocations count
+         |# - is ignored
+         |# - description (can be multi-line)
+         |# '\f' sign
+         |# ------------------------------------------
+         |14
+         |mypath
+         |org.scoverage
+         |test
+         |Trait
+         |org.scoverage.test
+         |mymethod
+         |100
+         |200
+         |4
+         |test
+         |DefDef
+         |true
+         |1
+         |false
+         |def test : String
+         |\f
+         |""".stripMargin.split(System.lineSeparator()).iterator
+    val statements = List(
+      Statement(
+        Location(
+          "org.scoverage",
+          "test",
+          "org.scoverage.test",
+          ClassType.Trait,
+          "mymethod",
+          new File(sourceRoot, "mypath").getCanonicalPath().toString()
+        ),
+        14,
+        100,
+        200,
+        4,
+        "def test : String",
+        "test",
+        "DefDef",
+        true,
+        1
+      )
+    )
+    val coverage = Serializer.deserialize(input, sourceRoot)
     assert(statements === coverage.statements.toList)
   }
 }


### PR DESCRIPTION
This also introduces a new config setting, `sourceRoot` that will need
to be set by the plugins using this to ensure that no matter where this
is executed from that the relativization process will work as expected.

Relates to #368 