### PR TITLE
Migrate from scalatest to munit.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtcrossproject.CrossProject
 import sbtcrossproject.CrossType
 
-val scalatestVersion = "3.2.10"
+val munitVersion = "0.7.29"
 val scalametaVersion = "4.4.28"
 val defaultScala213 = "2.13.6"
 val bin212 =
@@ -102,7 +102,7 @@ lazy val runtime = CrossProject(
     name := "scalac-scoverage-runtime",
     crossTarget := target.value / s"scala-${scalaVersion.value}",
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % scalatestVersion % Test
+      "org.scalameta" %% "munit" % munitVersion % Test
     ),
     sharedSettings
   )
@@ -125,7 +125,7 @@ lazy val plugin =
       crossVersion := CrossVersion.full,
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" %% "scala-xml" % "2.0.0",
-        "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+        "org.scalameta" %% "munit" % munitVersion % Test,
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided
       ),
       sharedSettings

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoberturaXmlWriterTest.scala
@@ -9,18 +9,13 @@ import scala.xml.Elem
 import scala.xml.XML
 import scala.xml.factory.XMLLoader
 
-import org.scalatest.BeforeAndAfter
-import org.scalatest.OneInstancePerTest
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import org.xml.sax.ErrorHandler
 import org.xml.sax.SAXParseException
 import scoverage.report.CoberturaXmlWriter
 
 /** @author Stephen Samuel */
-class CoberturaXmlWriterTest
-    extends AnyFunSuite
-    with BeforeAndAfter
-    with OneInstancePerTest {
+class CoberturaXmlWriterTest extends FunSuite {
 
   def tempDir(): File = {
     val dir = new File(IOUtils.getTempDirectory, UUID.randomUUID.toString)
@@ -227,16 +222,16 @@ class CoberturaXmlWriterTest
     builder.setErrorHandler(new ErrorHandler() {
       @Override
       def error(e: SAXParseException): Unit = {
-        fail(e)
+        fail(e.getMessage(), e.getCause())
       }
       @Override
       def fatalError(e: SAXParseException): Unit = {
-        fail(e)
+        fail(e.getMessage(), e.getCause())
       }
 
       @Override
       def warning(e: SAXParseException): Unit = {
-        fail(e)
+        fail(e.getMessage(), e.getCause())
       }
     })
     builder.parse(fileIn(dir))
@@ -329,8 +324,12 @@ class CoberturaXmlWriterTest
 
     val xml = customXML.loadFile(fileIn(dir))
 
-    assert((xml \\ "coverage" \ "@line-rate").text === "0.33", "line-rate")
-    assert((xml \\ "coverage" \ "@branch-rate").text === "0.50", "branch-rate")
+    assertEquals((xml \\ "coverage" \ "@line-rate").text, "0.33", "line-rate")
+    assertEquals(
+      (xml \\ "coverage" \ "@branch-rate").text,
+      "0.50",
+      "branch-rate"
+    )
 
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageAggregatorTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageAggregatorTest.scala
@@ -4,84 +4,83 @@ import java.io.File
 import java.io.FileWriter
 import java.util.UUID
 
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 import scoverage.report.CoverageAggregator
 
-class CoverageAggregatorTest extends AnyFreeSpec with Matchers {
+class CoverageAggregatorTest extends FunSuite {
 
   // Let current directory be our source root
   private val sourceRoot = new File(".").getCanonicalPath()
   private def canonicalPath(fileName: String) =
     new File(sourceRoot, fileName).getCanonicalPath()
 
-  "coverage aggregator" - {
-    "should merge coverage objects with same id" in {
+  test("should merge coverage objects with same id") {
 
-      val source = canonicalPath("com/scoverage/class.scala")
-      val location = Location(
-        "com.scoverage.foo",
-        "ServiceState",
-        "com.scoverage.foo.Service.ServiceState",
-        ClassType.Trait,
-        "methlab",
-        source
-      )
+    val source = canonicalPath("com/scoverage/class.scala")
+    val location = Location(
+      "com.scoverage.foo",
+      "ServiceState",
+      "com.scoverage.foo.Service.ServiceState",
+      ClassType.Trait,
+      "methlab",
+      source
+    )
 
-      val cov1Stmt1 = Statement(location, 1, 155, 176, 4, "", "", "", true, 1)
-      val cov1Stmt2 = Statement(location, 2, 200, 300, 5, "", "", "", false, 1)
-      val coverage1 = Coverage()
-      coverage1.add(cov1Stmt1.copy(count = 0))
-      coverage1.add(cov1Stmt2.copy(count = 0))
-      val dir1 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
-      dir1.mkdir()
-      Serializer.serialize(
-        coverage1,
-        Serializer.coverageFile(dir1),
+    val cov1Stmt1 = Statement(location, 1, 155, 176, 4, "", "", "", true, 1)
+    val cov1Stmt2 = Statement(location, 2, 200, 300, 5, "", "", "", false, 1)
+    val coverage1 = Coverage()
+    coverage1.add(cov1Stmt1.copy(count = 0))
+    coverage1.add(cov1Stmt2.copy(count = 0))
+    val dir1 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
+    dir1.mkdir()
+    Serializer.serialize(
+      coverage1,
+      Serializer.coverageFile(dir1),
+      new File(sourceRoot)
+    )
+    val measurementsFile1 =
+      new File(dir1, s"${Constants.MeasurementsPrefix}1")
+    val measurementsFile1Writer = new FileWriter(measurementsFile1)
+    measurementsFile1Writer.write("1\n2\n")
+    measurementsFile1Writer.close()
+
+    val cov2Stmt1 = Statement(location, 1, 95, 105, 19, "", "", "", false, 0)
+    val coverage2 = Coverage()
+    coverage2.add(cov2Stmt1)
+    val dir2 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
+    dir2.mkdir()
+    Serializer.serialize(
+      coverage2,
+      Serializer.coverageFile(dir2),
+      new File(sourceRoot)
+    )
+
+    val cov3Stmt1 =
+      Statement(location, 2, 14, 1515, 544, "", "", "", false, 1)
+    val coverage3 = Coverage()
+    coverage3.add(cov3Stmt1.copy(count = 0))
+    val dir3 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
+    dir3.mkdir()
+    Serializer.serialize(
+      coverage3,
+      Serializer.coverageFile(dir3),
+      new File(sourceRoot)
+    )
+    val measurementsFile3 =
+      new File(dir3, s"${Constants.MeasurementsPrefix}1")
+    val measurementsFile3Writer = new FileWriter(measurementsFile3)
+    measurementsFile3Writer.write("2\n")
+    measurementsFile3Writer.close()
+
+    val aggregated =
+      CoverageAggregator.aggregatedCoverage(
+        Seq(dir1, dir2, dir3),
         new File(sourceRoot)
       )
-      val measurementsFile1 =
-        new File(dir1, s"${Constants.MeasurementsPrefix}1")
-      val measurementsFile1Writer = new FileWriter(measurementsFile1)
-      measurementsFile1Writer.write("1\n2\n")
-      measurementsFile1Writer.close()
-
-      val cov2Stmt1 = Statement(location, 1, 95, 105, 19, "", "", "", false, 0)
-      val coverage2 = Coverage()
-      coverage2.add(cov2Stmt1)
-      val dir2 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
-      dir2.mkdir()
-      Serializer.serialize(
-        coverage2,
-        Serializer.coverageFile(dir2),
-        new File(sourceRoot)
-      )
-
-      val cov3Stmt1 =
-        Statement(location, 2, 14, 1515, 544, "", "", "", false, 1)
-      val coverage3 = Coverage()
-      coverage3.add(cov3Stmt1.copy(count = 0))
-      val dir3 = new File(IOUtils.getTempPath, UUID.randomUUID.toString)
-      dir3.mkdir()
-      Serializer.serialize(
-        coverage3,
-        Serializer.coverageFile(dir3),
-        new File(sourceRoot)
-      )
-      val measurementsFile3 =
-        new File(dir3, s"${Constants.MeasurementsPrefix}1")
-      val measurementsFile3Writer = new FileWriter(measurementsFile3)
-      measurementsFile3Writer.write("2\n")
-      measurementsFile3Writer.close()
-
-      val aggregated =
-        CoverageAggregator.aggregatedCoverage(
-          Seq(dir1, dir2, dir3),
-          new File(sourceRoot)
-        )
-      aggregated.statements.toSet.size shouldBe 4
-      aggregated.statements.map(_.copy(id = 0)).toSet shouldBe
-        Set(cov1Stmt1, cov1Stmt2, cov2Stmt1, cov3Stmt1).map(_.copy(id = 0))
-    }
+    assertEquals(aggregated.statements.toSet.size, 4)
+    assertEquals(
+      aggregated.statements.map(_.copy(id = 0)).toSet,
+      Set(cov1Stmt1, cov1Stmt2, cov2Stmt1, cov3Stmt1).map(_.copy(id = 0))
+    )
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageMetricsTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageMetricsTest.scala
@@ -1,29 +1,32 @@
 package scoverage
 
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 
-class CoverageMetricsTest extends AnyFreeSpec with Matchers {
+class CoverageMetricsTest extends FunSuite {
 
-  "no branches with at least one invoked statement should have 100% branch coverage" in {
+  test(
+    "no branches with at least one invoked statement should have 100% branch coverage"
+  ) {
     val metrics = new CoverageMetrics {
       override def statements: Iterable[Statement] =
         Seq(Statement(null, 0, 0, 0, 0, null, null, null, false, 1))
 
       override def ignoredStatements: Iterable[Statement] = Seq()
     }
-    metrics.branchCount shouldBe 0
-    metrics.branchCoverage shouldBe 1.0 +- 0.0001
+    assertEquals(metrics.branchCount, 0)
+    assertEqualsDouble(metrics.branchCoverage, 1.0, 0.0001)
   }
 
-  "no branches with no invoked statements should have 0% branch coverage" in {
+  test(
+    "no branches with no invoked statements should have 0% branch coverage"
+  ) {
     val metrics = new CoverageMetrics {
       override def statements: Iterable[Statement] =
         Seq(Statement(null, 0, 0, 0, 0, null, null, null, false, 0))
 
       override def ignoredStatements: Iterable[Statement] = Seq()
     }
-    metrics.branchCount shouldBe 0
-    metrics.branchCoverage shouldBe 0
+    assertEquals(metrics.branchCount, 0)
+    assertEquals(metrics.branchCoverage, 0.0)
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/CoverageTest.scala
@@ -1,18 +1,13 @@
 package scoverage
 
-import org.scalatest.BeforeAndAfter
-import org.scalatest.OneInstancePerTest
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /** @author Stephen Samuel */
-class CoverageTest
-    extends AnyFunSuite
-    with BeforeAndAfter
-    with OneInstancePerTest {
+class CoverageTest extends FunSuite {
 
   test("coverage for no statements is 1") {
     val coverage = Coverage()
-    assert(1.0 === coverage.statementCoverage)
+    assertEquals(1.0, coverage.statementCoverage)
   }
 
   test("coverage for no invoked statements is 0") {
@@ -31,7 +26,7 @@ class CoverageTest
         0
       )
     )
-    assert(0 === coverage.statementCoverage)
+    assertEquals(0.0, coverage.statementCoverage)
   }
 
   test("coverage for invoked statements") {
@@ -92,6 +87,6 @@ class CoverageTest
         0
       )
     )
-    assert(0.25 === coverage.statementCoverage)
+    assertEquals(0.25, coverage.statementCoverage)
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/IOUtilsTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/IOUtilsTest.scala
@@ -4,73 +4,74 @@ import java.io.File
 import java.io.FileWriter
 import java.util.UUID
 
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 
 /** @author Stephen Samuel */
-class IOUtilsTest extends AnyFreeSpec with OneInstancePerTest with Matchers {
+class IOUtilsTest extends FunSuite {
 
-  "io utils" - {
-    "should parse measurement files" in {
-      val file = File.createTempFile("scoveragemeasurementtest", "txt")
-      val writer = new FileWriter(file)
-      writer.write("1\n5\n9\n\n10\n")
-      writer.close()
-      val invoked = IOUtils.invoked(Seq(file))
-      assert(invoked === Set((1, ""), (5, ""), (9, ""), (10, "")))
+  test("should parse measurement files") {
+    val file = File.createTempFile("scoveragemeasurementtest", "txt")
+    val writer = new FileWriter(file)
+    writer.write("1\n5\n9\n\n10\n")
+    writer.close()
+    val invoked = IOUtils.invoked(Seq(file))
+    assertEquals(invoked, Set((1, ""), (5, ""), (9, ""), (10, "")))
 
+    file.delete()
+  }
+
+  test("should parse multiple measurement files") {
+    // clean up any existing measurement files
+    for (file <- IOUtils.findMeasurementFiles(IOUtils.getTempDirectory))
       file.delete()
-    }
-    "should parse multiple measurement files" in {
-      // clean up any existing measurement files
-      for (file <- IOUtils.findMeasurementFiles(IOUtils.getTempDirectory))
-        file.delete()
 
-      val file1 = File.createTempFile("scoverage.measurements.1", "txt")
-      val writer1 = new FileWriter(file1)
-      writer1.write("1\n5\n9\n\n10\n")
-      writer1.close()
+    val file1 = File.createTempFile("scoverage.measurements.1", "txt")
+    val writer1 = new FileWriter(file1)
+    writer1.write("1\n5\n9\n\n10\n")
+    writer1.close()
 
-      val file2 = File.createTempFile("scoverage.measurements.2", "txt")
-      val writer2 = new FileWriter(file2)
-      writer2.write("1\n7\n14\n\n2\n")
-      writer2.close()
+    val file2 = File.createTempFile("scoverage.measurements.2", "txt")
+    val writer2 = new FileWriter(file2)
+    writer2.write("1\n7\n14\n\n2\n")
+    writer2.close()
 
-      val files = IOUtils.findMeasurementFiles(file1.getParent)
-      val invoked = IOUtils.invoked(files.toIndexedSeq)
-      assert(
-        invoked === Set(
-          (1, ""),
-          (2, ""),
-          (5, ""),
-          (7, ""),
-          (9, ""),
-          (10, ""),
-          (14, "")
-        )
+    val files = IOUtils.findMeasurementFiles(file1.getParent)
+    val invoked = IOUtils.invoked(files.toIndexedSeq)
+    assertEquals(
+      invoked,
+      Set(
+        (1, ""),
+        (2, ""),
+        (5, ""),
+        (7, ""),
+        (9, ""),
+        (10, ""),
+        (14, "")
       )
+    )
 
-      file1.delete()
-      file2.delete()
-    }
-    "should deep search for scoverage-data directories" in {
-      // create new folder to hold all our data
-      val base = new File(IOUtils.getTempDirectory, UUID.randomUUID.toString)
+    file1.delete()
+    file2.delete()
+  }
+  test("should deep search for scoverage-data directories") {
+    // create new folder to hold all our data
+    val base = new File(IOUtils.getTempDirectory, UUID.randomUUID.toString)
 
-      val dataDir1 = new File(base, Constants.DataDir)
-      dataDir1.mkdirs() shouldBe true
+    val dataDir1 = new File(base, Constants.DataDir)
+    assertEquals(dataDir1.mkdirs(), true)
 
-      val subDir = new File(base, UUID.randomUUID.toString)
-      val dataDir2 = new File(subDir, Constants.DataDir)
-      dataDir2.mkdirs() shouldBe true
+    val subDir = new File(base, UUID.randomUUID.toString)
+    val dataDir2 = new File(subDir, Constants.DataDir)
+    assertEquals(dataDir2.mkdirs(), true)
 
-      val subSubDir = new File(subDir, UUID.randomUUID.toString)
-      val dataDir3 = new File(subSubDir, Constants.DataDir)
-      dataDir3.mkdirs() shouldBe true
+    val subSubDir = new File(subDir, UUID.randomUUID.toString)
+    val dataDir3 = new File(subSubDir, Constants.DataDir)
+    assertEquals(dataDir3.mkdirs(), true)
 
-      val dataDirs = IOUtils.scoverageDataDirsSearch(base)
-      dataDirs should contain only (dataDir1, dataDir2, dataDir3)
-    }
+    val dataDirs = IOUtils.scoverageDataDirsSearch(base)
+    assert(dataDirs.contains(dataDir1))
+    assert(dataDirs.contains(dataDir2))
+    assert(dataDirs.contains(dataDir3))
+    assertEquals(dataDirs.size, 3)
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/LocationTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/LocationTest.scala
@@ -1,258 +1,247 @@
 package scoverage
 
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 
-class LocationTest extends AnyFreeSpec with Matchers {
+class LocationTest extends FunSuite {
 
-  "location function" - {
-    "should correctly process top level types" - {
-      "for classes" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile("package com.test\nclass Sammy")
-        val loc = compiler.locations.result().find(_._1 == "Template").get._2
-        loc.packageName shouldBe "com.test"
-        loc.className shouldBe "Sammy"
-        loc.fullClassName shouldBe "com.test.Sammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Class
-        loc.sourcePath should endWith(".scala")
-      }
-      "for objects" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.test\nobject Bammy { def foo = Symbol(\"boo\") } "
-        )
-        val loc = compiler.locations.result().find(_._1 == "Template").get._2
-        loc.packageName shouldBe "com.test"
-        loc.className shouldBe "Bammy"
-        loc.fullClassName shouldBe "com.test.Bammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Object
-        loc.sourcePath should endWith(".scala")
-      }
-      "for traits" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.test\ntrait Gammy { def goo = Symbol(\"hoo\") } "
-        )
-        val loc = compiler.locations.result().find(_._1 == "Template").get._2
-        loc.packageName shouldBe "com.test"
-        loc.className shouldBe "Gammy"
-        loc.fullClassName shouldBe "com.test.Gammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Trait
-        loc.sourcePath should endWith(".scala")
-      }
-    }
-    "should correctly process methods" in {
-      val compiler = ScoverageCompiler.locationCompiler
-      compiler.compile(
-        "package com.methodtest \n class Hammy { def foo = Symbol(\"boo\") } "
-      )
-      val loc = compiler.locations.result().find(_._2.method == "foo").get._2
-      loc.packageName shouldBe "com.methodtest"
-      loc.className shouldBe "Hammy"
-      loc.fullClassName shouldBe "com.methodtest.Hammy"
-      loc.classType shouldBe ClassType.Class
-      loc.sourcePath should endWith(".scala")
-    }
-    "should correctly process nested methods" in {
-      val compiler = ScoverageCompiler.locationCompiler
-      compiler.compile(
-        "package com.methodtest \n class Hammy { def foo = { def goo = { getClass; 3 }; goo } } "
-      )
-      val loc = compiler.locations.result().find(_._2.method == "goo").get._2
-      loc.packageName shouldBe "com.methodtest"
-      loc.className shouldBe "Hammy"
-      loc.fullClassName shouldBe "com.methodtest.Hammy"
-      loc.classType shouldBe ClassType.Class
-      loc.sourcePath should endWith(".scala")
-    }
-    "should process anon functions as inside the enclosing method" in {
-      val compiler = ScoverageCompiler.locationCompiler
-      compiler.compile(
-        "package com.methodtest \n class Jammy { def moo = { Option(\"bat\").map(_.length) } } "
-      )
-      val loc = compiler.locations.result().find(_._1 == "Function").get._2
-      loc.packageName shouldBe "com.methodtest"
-      loc.className shouldBe "Jammy"
-      loc.fullClassName shouldBe "com.methodtest.Jammy"
-      loc.method shouldBe "moo"
-      loc.classType shouldBe ClassType.Class
-      loc.sourcePath should endWith(".scala")
-    }
-    "should use outer package" - {
-      "for nested classes" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.methodtest \n class Jammy { class Pammy } "
-        )
-        val loc =
-          compiler.locations.result().find(_._2.className == "Pammy").get._2
-        loc.packageName shouldBe "com.methodtest"
-        loc.className shouldBe "Pammy"
-        loc.fullClassName shouldBe "com.methodtest.Jammy.Pammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Class
-        loc.sourcePath should endWith(".scala")
-      }
-      "for nested objects" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.methodtest \n class Jammy { object Zammy } "
-        )
-        val loc =
-          compiler.locations.result().find(_._2.className == "Zammy").get._2
-        loc.packageName shouldBe "com.methodtest"
-        loc.className shouldBe "Zammy"
-        loc.fullClassName shouldBe "com.methodtest.Jammy.Zammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Object
-        loc.sourcePath should endWith(".scala")
-      }
-      "for nested traits" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.methodtest \n class Jammy { trait Mammy } "
-        )
-        val loc =
-          compiler.locations.result().find(_._2.className == "Mammy").get._2
-        loc.packageName shouldBe "com.methodtest"
-        loc.className shouldBe "Mammy"
-        loc.fullClassName shouldBe "com.methodtest.Jammy.Mammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Trait
-        loc.sourcePath should endWith(".scala")
-      }
-    }
-    "should support nested packages" - {
-      "for classes" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.a \n " +
-            "package b \n" +
-            "class Kammy "
-        )
-        val loc = compiler.locations.result().find(_._1 == "Template").get._2
-        loc.packageName shouldBe "com.a.b"
-        loc.className shouldBe "Kammy"
-        loc.fullClassName shouldBe "com.a.b.Kammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Class
-        loc.sourcePath should endWith(".scala")
-      }
-      "for objects" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.a \n " +
-            "package b \n" +
-            "object Kammy "
-        )
-        val loc = compiler.locations.result().find(_._1 == "Template").get._2
-        loc.packageName shouldBe "com.a.b"
-        loc.className shouldBe "Kammy"
-        loc.fullClassName shouldBe "com.a.b.Kammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Object
-        loc.sourcePath should endWith(".scala")
-      }
-      "for traits" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.a \n " +
-            "package b \n" +
-            "trait Kammy "
-        )
-        val loc = compiler.locations.result().find(_._1 == "Template").get._2
-        loc.packageName shouldBe "com.a.b"
-        loc.className shouldBe "Kammy"
-        loc.fullClassName shouldBe "com.a.b.Kammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Trait
-        loc.sourcePath should endWith(".scala")
-      }
-    }
-    "should use <none> method name" - {
-      "for class constructor body" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.b \n class Tammy { val name = Symbol(\"sam\") } "
-        )
-        val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
-        loc.packageName shouldBe "com.b"
-        loc.className shouldBe "Tammy"
-        loc.fullClassName shouldBe "com.b.Tammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Class
-        loc.sourcePath should endWith(".scala")
-      }
-      "for object constructor body" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.b \n object Yammy { val name = Symbol(\"sam\") } "
-        )
-        val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
-        loc.packageName shouldBe "com.b"
-        loc.className shouldBe "Yammy"
-        loc.fullClassName shouldBe "com.b.Yammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Object
-        loc.sourcePath should endWith(".scala")
-      }
-      "for trait constructor body" in {
-        val compiler = ScoverageCompiler.locationCompiler
-        compiler.compile(
-          "package com.b \n trait Wammy { val name = Symbol(\"sam\") } "
-        )
-        val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
-        loc.packageName shouldBe "com.b"
-        loc.className shouldBe "Wammy"
-        loc.fullClassName shouldBe "com.b.Wammy"
-        loc.method shouldBe "<none>"
-        loc.classType shouldBe ClassType.Trait
-        loc.sourcePath should endWith(".scala")
-      }
-    }
-    "anon class should report enclosing class" in {
-      val compiler = ScoverageCompiler.locationCompiler
-      compiler
-        .compile(
-          "package com.a; object A { def foo(b : B) : Unit = b.invoke }; trait B { def invoke : Unit }; class C { A.foo(new B { def invoke = () }) }"
-        )
-      val loc = compiler.locations.result().filter(_._1 == "Template").last._2
-      loc.packageName shouldBe "com.a"
-      loc.className shouldBe "C"
-      loc.fullClassName shouldBe "com.a.C"
-      loc.method shouldBe "<none>"
-      loc.classType shouldBe ClassType.Class
-      loc.sourcePath should endWith(".scala")
-    }
-    "anon class implemented method should report enclosing method" in {
-      val compiler = ScoverageCompiler.locationCompiler
-      compiler.compile(
+  test("top level for classes") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile("package com.test\nclass Sammy")
+    val loc = compiler.locations.result().find(_._1 == "Template").get._2
+    assertEquals(loc.packageName, "com.test")
+    assertEquals(loc.className, "Sammy")
+    assertEquals(loc.fullClassName, "com.test.Sammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("top level for objects") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.test\nobject Bammy { def foo = Symbol(\"boo\") } "
+    )
+    val loc = compiler.locations.result().find(_._1 == "Template").get._2
+    assertEquals(loc.packageName, "com.test")
+    assertEquals(loc.className, "Bammy")
+    assertEquals(loc.fullClassName, "com.test.Bammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Object)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("top level for traits") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.test\ntrait Gammy { def goo = Symbol(\"hoo\") } "
+    )
+    val loc = compiler.locations.result().find(_._1 == "Template").get._2
+    assertEquals(loc.packageName, "com.test")
+    assertEquals(loc.className, "Gammy")
+    assertEquals(loc.fullClassName, "com.test.Gammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Trait)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("should correctly process methods") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.methodtest \n class Hammy { def foo = Symbol(\"boo\") } "
+    )
+    val loc = compiler.locations.result().find(_._2.method == "foo").get._2
+    assertEquals(loc.packageName, "com.methodtest")
+    assertEquals(loc.className, "Hammy")
+    assertEquals(loc.fullClassName, "com.methodtest.Hammy")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("should correctly process nested methods") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.methodtest \n class Hammy { def foo = { def goo = { getClass; 3 }; goo } } "
+    )
+    val loc = compiler.locations.result().find(_._2.method == "goo").get._2
+    assertEquals(loc.packageName, "com.methodtest")
+    assertEquals(loc.className, "Hammy")
+    assertEquals(loc.fullClassName, "com.methodtest.Hammy")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("should process anon functions as inside the enclosing method") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.methodtest \n class Jammy { def moo = { Option(\"bat\").map(_.length) } } "
+    )
+    val loc = compiler.locations.result().find(_._1 == "Function").get._2
+    assertEquals(loc.packageName, "com.methodtest")
+    assertEquals(loc.className, "Jammy")
+    assertEquals(loc.fullClassName, "com.methodtest.Jammy")
+    assertEquals(loc.method, "moo")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("should use outer package for nested classes") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.methodtest \n class Jammy { class Pammy } "
+    )
+    val loc =
+      compiler.locations.result().find(_._2.className == "Pammy").get._2
+    assertEquals(loc.packageName, "com.methodtest")
+    assertEquals(loc.className, "Pammy")
+    assertEquals(loc.fullClassName, "com.methodtest.Jammy.Pammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("for nested objects") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.methodtest \n class Jammy { object Zammy } "
+    )
+    val loc =
+      compiler.locations.result().find(_._2.className == "Zammy").get._2
+    assertEquals(loc.packageName, "com.methodtest")
+    assertEquals(loc.className, "Zammy")
+    assertEquals(loc.fullClassName, "com.methodtest.Jammy.Zammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Object)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("for nested traits") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.methodtest \n class Jammy { trait Mammy } "
+    )
+    val loc =
+      compiler.locations.result().find(_._2.className == "Mammy").get._2
+    assertEquals(loc.packageName, "com.methodtest")
+    assertEquals(loc.className, "Mammy")
+    assertEquals(loc.fullClassName, "com.methodtest.Jammy.Mammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Trait)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("should support nested packages for classes") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.a \n " +
+        "package b \n" +
+        "class Kammy "
+    )
+    val loc = compiler.locations.result().find(_._1 == "Template").get._2
+    assertEquals(loc.packageName, "com.a.b")
+    assertEquals(loc.className, "Kammy")
+    assertEquals(loc.fullClassName, "com.a.b.Kammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("for objects") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.a \n " +
+        "package b \n" +
+        "object Kammy "
+    )
+    val loc = compiler.locations.result().find(_._1 == "Template").get._2
+    assertEquals(loc.packageName, "com.a.b")
+    assertEquals(loc.className, "Kammy")
+    assertEquals(loc.fullClassName, "com.a.b.Kammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Object)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("for traits") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.a \n " +
+        "package b \n" +
+        "trait Kammy "
+    )
+    val loc = compiler.locations.result().find(_._1 == "Template").get._2
+    assertEquals(loc.packageName, "com.a.b")
+    assertEquals(loc.className, "Kammy")
+    assertEquals(loc.fullClassName, "com.a.b.Kammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Trait)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("should use <none> method name for class constructor body") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.b \n class Tammy { val name = Symbol(\"sam\") } "
+    )
+    val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
+    assertEquals(loc.packageName, "com.b")
+    assertEquals(loc.className, "Tammy")
+    assertEquals(loc.fullClassName, "com.b.Tammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("for object constructor body") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.b \n object Yammy { val name = Symbol(\"sam\") } "
+    )
+    val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
+    assertEquals(loc.packageName, "com.b")
+    assertEquals(loc.className, "Yammy")
+    assertEquals(loc.fullClassName, "com.b.Yammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Object)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("for trait constructor body") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.b \n trait Wammy { val name = Symbol(\"sam\") } "
+    )
+    val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
+    assertEquals(loc.packageName, "com.b")
+    assertEquals(loc.className, "Wammy")
+    assertEquals(loc.fullClassName, "com.b.Wammy")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Trait)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("anon class should report enclosing class") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler
+      .compile(
         "package com.a; object A { def foo(b : B) : Unit = b.invoke }; trait B { def invoke : Unit }; class C { A.foo(new B { def invoke = () }) }"
       )
-      val loc = compiler.locations.result().filter(_._1 == "DefDef").last._2
-      loc.packageName shouldBe "com.a"
-      loc.className shouldBe "C"
-      loc.fullClassName shouldBe "com.a.C"
-      loc.method shouldBe "invoke"
-      loc.classType shouldBe ClassType.Class
-      loc.sourcePath should endWith(".scala")
-    }
-    "doubly nested classes should report correct fullClassName" in {
-      val compiler = ScoverageCompiler.locationCompiler
-      compiler.compile(
-        "package com.a \n object Foo { object Boo { object Moo { val name = Symbol(\"sam\") } } }"
-      )
-      val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
-      loc.packageName shouldBe "com.a"
-      loc.className shouldBe "Moo"
-      loc.fullClassName shouldBe "com.a.Foo.Boo.Moo"
-      loc.method shouldBe "<none>"
-      loc.classType shouldBe ClassType.Object
-      loc.sourcePath should endWith(".scala")
-    }
+    val loc = compiler.locations.result().filter(_._1 == "Template").last._2
+    assertEquals(loc.packageName, "com.a")
+    assertEquals(loc.className, "C")
+    assertEquals(loc.fullClassName, "com.a.C")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("anon class implemented method should report enclosing method") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.a; object A { def foo(b : B) : Unit = b.invoke }; trait B { def invoke : Unit }; class C { A.foo(new B { def invoke = () }) }"
+    )
+    val loc = compiler.locations.result().filter(_._1 == "DefDef").last._2
+    assertEquals(loc.packageName, "com.a")
+    assertEquals(loc.className, "C")
+    assertEquals(loc.fullClassName, "com.a.C")
+    assertEquals(loc.method, "invoke")
+    assertEquals(loc.classType, ClassType.Class)
+    assert(loc.sourcePath.endsWith(".scala"))
+  }
+  test("doubly nested classes should report correct fullClassName") {
+    val compiler = ScoverageCompiler.locationCompiler
+    compiler.compile(
+      "package com.a \n object Foo { object Boo { object Moo { val name = Symbol(\"sam\") } } }"
+    )
+    val loc = compiler.locations.result().find(_._1 == "ValDef").get._2
+    assertEquals(loc.packageName, "com.a")
+    assertEquals(loc.className, "Moo")
+    assertEquals(loc.fullClassName, "com.a.Foo.Boo.Moo")
+    assertEquals(loc.method, "<none>")
+    assertEquals(loc.classType, ClassType.Object)
+    assert(loc.sourcePath.endsWith(".scala"))
   }
 }

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginASTSupportTest.scala
@@ -1,16 +1,14 @@
 package scoverage
 
-import org.scalatest._
-import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.Future
+
+import munit.FunSuite
+import munit.GenericAfterEach
 
 /** @author Stephen Samuel */
-class PluginASTSupportTest
-    extends AnyFunSuite
-    with OneInstancePerTest
-    with BeforeAndAfterEachTestData
-    with MacroSupport {
+class PluginASTSupportTest extends FunSuite with MacroSupport {
 
-  override protected def afterEach(testData: TestData): Unit = {
+  override def afterEach(context: GenericAfterEach[Future[Any]]): Unit = {
     val compiler = ScoverageCompiler.default
     assert(!compiler.reporter.hasErrors)
   }
@@ -140,7 +138,7 @@ class PluginASTSupportTest
   }
 
   // https://github.com/skinny-framework/skinny-framework/issues/97
-  ignore("macro range positions should not break plugin") {
+  test("macro range positions should not break plugin".ignore) {
     val compiler = ScoverageCompiler.default
     macroSupportDeps.foreach(compiler.addToClassPath(_))
     compiler.compileCodeSnippet(s"""import scoverage.macrosupport.Tester

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
@@ -1,18 +1,12 @@
 package scoverage
 
-import org.scalatest.BeforeAndAfterEachTestData
-import org.scalatest.OneInstancePerTest
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /** https://github.com/scoverage/scalac-scoverage-plugin/issues/196
   */
-class PluginCoverageScalaJsTest
-    extends AnyFunSuite
-    with OneInstancePerTest
-    with BeforeAndAfterEachTestData
-    with MacroSupport {
+class PluginCoverageScalaJsTest extends FunSuite with MacroSupport {
 
-  ignore("scoverage should ignore default undefined parameter") {
+  test("scoverage should ignore default undefined parameter".ignore) {
     val compiler = ScoverageCompiler.default
     compiler.compileCodeSnippet(
       """import scala.scalajs.js

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -1,15 +1,9 @@
 package scoverage
 
-import org.scalatest.BeforeAndAfterEachTestData
-import org.scalatest.OneInstancePerTest
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /** @author Stephen Samuel */
-class PluginCoverageTest
-    extends AnyFunSuite
-    with OneInstancePerTest
-    with BeforeAndAfterEachTestData
-    with MacroSupport {
+class PluginCoverageTest extends FunSuite with MacroSupport {
 
   test("scoverage should instrument default arguments with methods") {
     val compiler = ScoverageCompiler.default
@@ -308,8 +302,8 @@ class PluginCoverageTest
     compiler.assertNoCoverage()
   }
 
-  ignore(
-    "plugin should not instrument expanded macro code http://github.com/skinny-framework/skinny-framework/issues/97"
+  test(
+    "plugin should not instrument expanded macro code http://github.com/skinny-framework/skinny-framework/issues/97".ignore
   ) {
     val compiler = ScoverageCompiler.default
     macroSupportDeps.foreach(compiler.addToClassPath(_))
@@ -323,8 +317,8 @@ class PluginCoverageTest
     compiler.assertNoCoverage()
   }
 
-  ignore(
-    "plugin should handle return inside catch github.com/scoverage/scalac-scoverage-plugin/issues/93"
+  test(
+    "plugin should handle return inside catch github.com/scoverage/scalac-scoverage-plugin/issues/93".ignore
   ) {
     val compiler = ScoverageCompiler.default
     compiler.compileCodeSnippet(

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
@@ -5,227 +5,232 @@ import scala.reflect.internal.util.NoFile
 import scala.reflect.internal.util.SourceFile
 import scala.reflect.io.VirtualFile
 
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 
-class RegexCoverageFilterTest extends AnyFreeSpec with Matchers {
+class RegexCoverageFilterTest extends FunSuite {
 
-  "isClassIncluded" - {
-
-    "should return true for empty excludes" in {
-      assert(new RegexCoverageFilter(Nil, Nil, Nil).isClassIncluded("x"))
-    }
-
-    "should not crash for empty input" in {
-      assert(new RegexCoverageFilter(Nil, Nil, Nil).isClassIncluded(""))
-    }
-
-    "should exclude scoverage -> scoverage" in {
-      assert(
-        !new RegexCoverageFilter(Seq("scoverage"), Nil, Nil)
-          .isClassIncluded("scoverage")
-      )
-    }
-
-    "should include scoverage -> scoverageeee" in {
-      assert(
-        new RegexCoverageFilter(Seq("scoverage"), Nil, Nil)
-          .isClassIncluded("scoverageeee")
-      )
-    }
-
-    "should exclude scoverage* -> scoverageeee" in {
-      assert(
-        !new RegexCoverageFilter(Seq("scoverage*"), Nil, Nil)
-          .isClassIncluded("scoverageeee")
-      )
-    }
-
-    "should include eee -> scoverageeee" in {
-      assert(
-        new RegexCoverageFilter(Seq("eee"), Nil, Nil)
-          .isClassIncluded("scoverageeee")
-      )
-    }
-
-    "should exclude .*eee -> scoverageeee" in {
-      assert(
-        !new RegexCoverageFilter(Seq(".*eee"), Nil, Nil)
-          .isClassIncluded("scoverageeee")
-      )
-    }
+  test("isClassIncluded should return true for empty excludes") {
+    assert(new RegexCoverageFilter(Nil, Nil, Nil).isClassIncluded("x"))
   }
-  "isFileIncluded" - {
-    val abstractFile = new VirtualFile("sammy.scala")
-    "should return true for empty excludes" in {
-      val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
-      new RegexCoverageFilter(Nil, Nil, Nil).isFileIncluded(file) shouldBe true
-    }
-    "should exclude by filename" in {
-      val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
-      new RegexCoverageFilter(Nil, Seq("sammy"), Nil)
-        .isFileIncluded(file) shouldBe false
-    }
-    "should exclude by regex wildcard" in {
-      val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
-      new RegexCoverageFilter(Nil, Seq("sam.*"), Nil)
-        .isFileIncluded(file) shouldBe false
-    }
-    "should not exclude non matching regex" in {
-      val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
+
+  test("should not crash for empty input") {
+    assert(new RegexCoverageFilter(Nil, Nil, Nil).isClassIncluded(""))
+  }
+
+  test("should exclude scoverage -> scoverage") {
+    assert(
+      !new RegexCoverageFilter(Seq("scoverage"), Nil, Nil)
+        .isClassIncluded("scoverage")
+    )
+  }
+
+  test("should include scoverage -> scoverageeee") {
+    assert(
+      new RegexCoverageFilter(Seq("scoverage"), Nil, Nil)
+        .isClassIncluded("scoverageeee")
+    )
+  }
+
+  test("should exclude scoverage* -> scoverageeee") {
+    assert(
+      !new RegexCoverageFilter(Seq("scoverage*"), Nil, Nil)
+        .isClassIncluded("scoverageeee")
+    )
+  }
+
+  test("should include eee -> scoverageeee") {
+    assert(
+      new RegexCoverageFilter(Seq("eee"), Nil, Nil)
+        .isClassIncluded("scoverageeee")
+    )
+  }
+
+  test("should exclude .*eee -> scoverageeee") {
+    assert(
+      !new RegexCoverageFilter(Seq(".*eee"), Nil, Nil)
+        .isClassIncluded("scoverageeee")
+    )
+  }
+
+  val abstractFile = new VirtualFile("sammy.scala")
+
+  test("isFileIncluded should return true for empty excludes") {
+    val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
+    assert(new RegexCoverageFilter(Nil, Nil, Nil).isFileIncluded(file))
+  }
+
+  test("should exclude by filename") {
+    val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
+    assert(
+      !new RegexCoverageFilter(Nil, Seq("sammy"), Nil)
+        .isFileIncluded(file)
+    )
+  }
+
+  test("should exclude by regex wildcard") {
+    val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
+    assert(
+      !new RegexCoverageFilter(Nil, Seq("sam.*"), Nil)
+        .isFileIncluded(file)
+    )
+  }
+
+  test("should not exclude non matching regex") {
+    val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
+    assert(
       new RegexCoverageFilter(Nil, Seq("qweqeqwe"), Nil)
-        .isFileIncluded(file) shouldBe true
-    }
+        .isFileIncluded(file)
+    )
   }
-  "isSymbolIncluded" - {
-    val options = new ScoverageOptions()
-    "should return true for empty excludes" in {
-      assert(new RegexCoverageFilter(Nil, Nil, Nil).isSymbolIncluded("x"))
-    }
 
-    "should not crash for empty input" in {
-      assert(new RegexCoverageFilter(Nil, Nil, Nil).isSymbolIncluded(""))
-    }
+  val options = new ScoverageOptions()
 
-    "should exclude scoverage -> scoverage" in {
-      assert(
-        !new RegexCoverageFilter(Nil, Nil, Seq("scoverage"))
-          .isSymbolIncluded("scoverage")
-      )
-    }
-
-    "should include scoverage -> scoverageeee" in {
-      assert(
-        new RegexCoverageFilter(Nil, Nil, Seq("scoverage"))
-          .isSymbolIncluded("scoverageeee")
-      )
-    }
-    "should exclude scoverage* -> scoverageeee" in {
-      assert(
-        !new RegexCoverageFilter(Nil, Nil, Seq("scoverage*"))
-          .isSymbolIncluded("scoverageeee")
-      )
-    }
-
-    "should include eee -> scoverageeee" in {
-      assert(
-        new RegexCoverageFilter(Nil, Nil, Seq("eee"))
-          .isSymbolIncluded("scoverageeee")
-      )
-    }
-
-    "should exclude .*eee -> scoverageeee" in {
-      assert(
-        !new RegexCoverageFilter(Nil, Nil, Seq(".*eee"))
-          .isSymbolIncluded("scoverageeee")
-      )
-    }
-    "should exclude scala.reflect.api.Exprs.Expr" in {
-      assert(
-        !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
-          .isSymbolIncluded("scala.reflect.api.Exprs.Expr")
-      )
-    }
-    "should exclude scala.reflect.macros.Universe.Tree" in {
-      assert(
-        !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
-          .isSymbolIncluded("scala.reflect.macros.Universe.Tree")
-      )
-    }
-    "should exclude scala.reflect.api.Trees.Tree" in {
-      assert(
-        !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
-          .isSymbolIncluded("scala.reflect.api.Trees.Tree")
-      )
-    }
+  test("isSymbolIncluded should return true for empty excludes") {
+    assert(new RegexCoverageFilter(Nil, Nil, Nil).isSymbolIncluded("x"))
   }
-  "getExcludedLineNumbers" - {
-    "should exclude no lines if no magic comments are found" in {
-      val file =
-        """1
-          |2
-          |3
-          |4
-          |5
-          |6
-          |7
-          |8
+
+  test("should not crash for empty input") {
+    assert(new RegexCoverageFilter(Nil, Nil, Nil).isSymbolIncluded(""))
+  }
+
+  test("should exclude scoverage -> scoverage") {
+    assert(
+      !new RegexCoverageFilter(Nil, Nil, Seq("scoverage"))
+        .isSymbolIncluded("scoverage")
+    )
+  }
+
+  test("should include scoverage -> scoverageeee") {
+    assert(
+      new RegexCoverageFilter(Nil, Nil, Seq("scoverage"))
+        .isSymbolIncluded("scoverageeee")
+    )
+  }
+  test("should exclude scoverage* -> scoverageeee") {
+    assert(
+      !new RegexCoverageFilter(Nil, Nil, Seq("scoverage*"))
+        .isSymbolIncluded("scoverageeee")
+    )
+  }
+
+  test("should include eee -> scoverageeee") {
+    assert(
+      new RegexCoverageFilter(Nil, Nil, Seq("eee"))
+        .isSymbolIncluded("scoverageeee")
+    )
+  }
+
+  test("should exclude .*eee -> scoverageeee") {
+    assert(
+      !new RegexCoverageFilter(Nil, Nil, Seq(".*eee"))
+        .isSymbolIncluded("scoverageeee")
+    )
+  }
+  test("should exclude scala.reflect.api.Exprs.Expr") {
+    assert(
+      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
+        .isSymbolIncluded("scala.reflect.api.Exprs.Expr")
+    )
+  }
+  test("should exclude scala.reflect.macros.Universe.Tree") {
+    assert(
+      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
+        .isSymbolIncluded("scala.reflect.macros.Universe.Tree")
+    )
+  }
+  test("should exclude scala.reflect.api.Trees.Tree") {
+    assert(
+      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
+        .isSymbolIncluded("scala.reflect.api.Trees.Tree")
+    )
+  }
+  test(
+    "getExcludedLineNumbers should exclude no lines if no magic comments are found"
+  ) {
+    val file =
+      """1
+        |2
+        |3
+        |4
+        |5
+        |6
+        |7
+        |8
         """.stripMargin
 
-      val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
-        .getExcludedLineNumbers(mockSourceFile(file))
-      numbers === List.empty
-    }
-    "should exclude lines between magic comments" in {
-      val file =
-        """1
-          |2
-          |3
-          |  // $COVERAGE-OFF$
-          |5
-          |6
-          |7
-          |8
-          |    // $COVERAGE-ON$
-          |10
-          |11
-          |    // $COVERAGE-OFF$
-          |13
-          |    // $COVERAGE-ON$
-          |15
-          |16
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+      .getExcludedLineNumbers(mockSourceFile(file))
+    assertEquals(numbers, List.empty)
+  }
+  test("should exclude lines between magic comments") {
+    val file =
+      """1
+        |2
+        |3
+        |  // $COVERAGE-OFF$
+        |5
+        |6
+        |7
+        |8
+        |    // $COVERAGE-ON$
+        |10
+        |11
+        |    // $COVERAGE-OFF$
+        |13
+        |    // $COVERAGE-ON$
+        |15
+        |16
         """.stripMargin
 
-      val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
-        .getExcludedLineNumbers(mockSourceFile(file))
-      numbers === List(Range(4, 9), Range(12, 14))
-    }
-    "should exclude all lines after an upaired magic comment" in {
-      val file =
-        """1
-          |2
-          |3
-          |  // $COVERAGE-OFF$
-          |5
-          |6
-          |7
-          |8
-          |    // $COVERAGE-ON$
-          |10
-          |11
-          |    // $COVERAGE-OFF$
-          |13
-          |14
-          |15
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+      .getExcludedLineNumbers(mockSourceFile(file))
+    assertEquals(numbers, List(Range(4, 9), Range(12, 14)))
+  }
+  test("should exclude all lines after an upaired magic comment") {
+    val file =
+      """1
+        |2
+        |3
+        |  // $COVERAGE-OFF$
+        |5
+        |6
+        |7
+        |8
+        |    // $COVERAGE-ON$
+        |10
+        |11
+        |    // $COVERAGE-OFF$
+        |13
+        |14
+        |15
         """.stripMargin
 
-      val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
-        .getExcludedLineNumbers(mockSourceFile(file))
-      numbers === List(Range(4, 9), Range(12, 16))
-    }
-    "should allow text comments on the same line as the markers" in {
-      val file =
-        """1
-          |2
-          |3
-          |  // $COVERAGE-OFF$ because the next lines are boring
-          |5
-          |6
-          |7
-          |8
-          |    // $COVERAGE-ON$ resume coverage here
-          |10
-          |11
-          |    // $COVERAGE-OFF$ but ignore this bit
-          |13
-          |14
-          |15
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+      .getExcludedLineNumbers(mockSourceFile(file))
+    assertEquals(numbers, List(Range(4, 9), Range(12, 16)))
+  }
+  test("should allow text comments on the same line as the markers") {
+    val file =
+      """1
+        |2
+        |3
+        |  // $COVERAGE-OFF$ because the next lines are boring
+        |5
+        |6
+        |7
+        |8
+        |    // $COVERAGE-ON$ resume coverage here
+        |10
+        |11
+        |    // $COVERAGE-OFF$ but ignore this bit
+        |13
+        |14
+        |15
         """.stripMargin
 
-      val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
-        .getExcludedLineNumbers(mockSourceFile(file))
-      numbers === List(Range(4, 9), Range(12, 16))
-    }
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+      .getExcludedLineNumbers(mockSourceFile(file))
+    assertEquals(numbers, List(Range(4, 9), Range(12, 16)))
   }
 
   private def mockSourceFile(contents: String): SourceFile = {

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageHtmlWriterTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageHtmlWriterTest.scala
@@ -6,10 +6,10 @@ import java.util.UUID
 import scala.io.Source
 import scala.xml.XML
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import scoverage.report.ScoverageHtmlWriter
 
-class ScoverageHtmlWriterTest extends AnyFunSuite {
+class ScoverageHtmlWriterTest extends FunSuite {
 
   val rootDirForClasses = new File(
     getClass.getResource("forHtmlWriter/src/main/scala/").getFile
@@ -111,7 +111,7 @@ class ScoverageHtmlWriterTest extends AnyFunSuite {
       val links = for (node <- xml \\ "a") yield {
         node.attribute("href") match {
           case Some(url) => url.toString
-          case None      => fail()
+          case None      => fail("href isn't a url")
         }
       }
 

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/SerializerTest.scala
@@ -3,10 +3,9 @@ package scoverage
 import java.io.File
 import java.io.StringWriter
 
-import org.scalatest.OneInstancePerTest
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SerializerTest extends AnyFunSuite with OneInstancePerTest {
+class SerializerTest extends FunSuite {
   private val sourceRoot = new File(".").getCanonicalFile()
 
   test("coverage should be serializable into plain text") {
@@ -73,7 +72,7 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
          |""".stripMargin
     val writer = new StringWriter() //TODO-use UTF-8
     val actual = Serializer.serialize(coverage, writer, sourceRoot)
-    assert(expected === writer.toString)
+    assertEquals(expected, writer.toString)
   }
 
   test("coverage should be deserializable from plain text") {
@@ -140,7 +139,7 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
       )
     )
     val coverage = Serializer.deserialize(input, sourceRoot)
-    assert(statements === coverage.statements.toList)
+    assertEquals(statements, coverage.statements.toList)
   }
   test("coverage should serialize sourcePath relatively") {
     val coverage = Coverage()
@@ -206,7 +205,7 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
          |""".stripMargin
     val writer = new StringWriter() //TODO-use UTF-8
     val actual = Serializer.serialize(coverage, writer, sourceRoot)
-    assert(expected === writer.toString)
+    assertEquals(expected, writer.toString)
   }
 
   test("coverage should deserialize sourcePath by prefixing cwd") {
@@ -271,6 +270,6 @@ class SerializerTest extends AnyFunSuite with OneInstancePerTest {
       )
     )
     val coverage = Serializer.deserialize(input, sourceRoot)
-    assert(statements === coverage.statements.toList)
+    assertEquals(statements, coverage.statements.toList)
   }
 }

--- a/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerConcurrencyTest.scala
+++ b/scalac-scoverage-runtime/jvm/src/test/scala/scoverage/InvokerConcurrencyTest.scala
@@ -6,19 +6,18 @@ import java.util.concurrent.Executors
 import scala.concurrent._
 import scala.concurrent.duration._
 
-import org.scalatest.BeforeAndAfter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /** Verify that [[Invoker.invoked()]] is thread-safe
   */
-class InvokerConcurrencyTest extends AnyFunSuite with BeforeAndAfter {
+class InvokerConcurrencyTest extends FunSuite {
 
   implicit val executor =
     ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8))
 
   val measurementDir = new File("target/invoker-test.measurement")
 
-  before {
+  override def beforeAll(): Unit = {
     deleteMeasurementFiles()
     measurementDir.mkdirs()
   }
@@ -43,10 +42,10 @@ class InvokerConcurrencyTest extends AnyFunSuite with BeforeAndAfter {
     val measurementFiles = Invoker.findMeasurementFiles(measurementDir)
     val idsFromFile = Invoker.invoked(measurementFiles.toIndexedSeq)
 
-    idsFromFile === testIds
+    assertEquals(idsFromFile, testIds)
   }
 
-  after {
+  override def afterAll(): Unit = {
     deleteMeasurementFiles()
     measurementDir.delete()
   }

--- a/scalac-scoverage-runtime/shared/src/test/scala/scoverage/InvokerMultiModuleTest.scala
+++ b/scalac-scoverage-runtime/shared/src/test/scala/scoverage/InvokerMultiModuleTest.scala
@@ -1,19 +1,18 @@
 package scoverage
 
-import org.scalatest.BeforeAndAfter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import scoverage.Platform.File
 
 /** Verify that [[Invoker.invoked()]] can handle a multi-module project
   */
-class InvokerMultiModuleTest extends AnyFunSuite with BeforeAndAfter {
+class InvokerMultiModuleTest extends FunSuite {
 
   val measurementDir = Array(
     new File("target/invoker-test.measurement0"),
     new File("target/invoker-test.measurement1")
   )
 
-  before {
+  override def beforeAll(): Unit = {
     deleteMeasurementFiles()
     measurementDir.foreach(_.mkdirs())
   }
@@ -24,20 +23,23 @@ class InvokerMultiModuleTest extends AnyFunSuite with BeforeAndAfter {
 
     val testIds: Set[Int] = (1 to 10).toSet
 
-    testIds.map { i: Int => Invoker.invoked(i, measurementDir(i % 2).toString) }
+    testIds.map((i: Int) =>
+      Invoker.invoked(i, measurementDir(i % 2).toString())
+    )
 
     // Verify measurements went to correct directory
     val measurementFiles0 = Invoker.findMeasurementFiles(measurementDir(0))
     val idsFromFile0 = Invoker.invoked(measurementFiles0.toIndexedSeq)
 
-    idsFromFile0 === testIds.filter { i: Int => i % 2 == 0 }
+    assertEquals(idsFromFile0, testIds.filter((i: Int) => i % 2 == 0))
 
-    val measurementFiles1 = Invoker.findMeasurementFiles(measurementDir(0))
+    val measurementFiles1 = Invoker.findMeasurementFiles(measurementDir(1))
     val idsFromFile1 = Invoker.invoked(measurementFiles1.toIndexedSeq)
-    idsFromFile1 === testIds.filter { i: Int => i % 2 == 1 }
+
+    assertEquals(idsFromFile1, testIds.filter((i: Int) => i % 2 == 1))
   }
 
-  after {
+  override def afterAll(): Unit = {
     deleteMeasurementFiles()
     measurementDir.foreach(_.delete())
   }


### PR DESCRIPTION
This is an opinionated change, but I'm a firm believer in munit.
There were some test issues previously that were pretty hard to debug
due to the nasty diffs that scalatest gives you compared to munit. Plus
when doing the migration I actually found some mistakes in the tests that
were false positives which switching from === to `assertEquals` unveiled.

It's a pretty straightforward migration.