### PR TITLE
dep: bump scalajs to 1.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,14 @@ lazy val runtime = CrossProject(
     Test / fork := true
   )
   .jsSettings(
-    scalaJSStage := FastOptStage
+    scalaJSStage := FastOptStage,
+    // While not exactlu ideal, this is only used in the invoker to assign a
+    // unique id to ensure measurements have unique ids. It's never exposed to
+    // the user and doesn't touch anything sensitve, so we should have no
+    // issues here. Still, I don't like having this, so we should try to
+    // replace it.
+    libraryDependencies += ("org.scala-js" %%% "scalajs-fake-insecure-java-securerandom" % "1.0.0")
+      .cross(CrossVersion.for3Use2_13)
   )
 
 lazy val `runtimeJVM` = runtime.jvm

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 


### PR DESCRIPTION
NOTE: We do add in
https://github.com/scala-js/scala-js-fake-insecure-java-securerandom.
You can see the full context to why here:
https://github.com/scala-js/scala-js/security/advisories/GHSA-j2f9-w8wh-9ww4.
However, we don't use this for anything sensitive here, but rather just
the generation of non user facing unique ids by the invoker. I've
included this temporary just to bump, and will address at a later time.