### PR TITLE
Re-enable `PluginCoverageScalaJsTest`, fix `dangling UndefinedParam` bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,11 +154,7 @@ lazy val plugin =
       crossTarget := target.value / s"scala-${scalaVersion.value}",
       crossScalaVersions := bin212 ++ bin213,
       crossVersion := CrossVersion.full,
-      libraryDependencies ++= Seq(
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
-        "org.scala-js" %% "scalajs-compiler" % scalaJSVersion % Test cross CrossVersion.full,
-        "org.scala-js" %% "scalajs-library" % scalaJSVersion % Test
-      ),
+      libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
       sharedSettings
     )
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -152,10 +152,7 @@ lazy val plugin =
       crossTarget := target.value / s"scala-${scalaVersion.value}",
       crossScalaVersions := bin212 ++ bin213,
       crossVersion := CrossVersion.full,
-      libraryDependencies ++= Seq(
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
-        "org.scala-js" %% "scalajs-compiler" % scalaJSVersion % Test cross CrossVersion.full
-      ),
+      libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
       sharedSettings
     )
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -183,6 +183,7 @@ lazy val reporter =
 lazy val buildInfo =
   project
     .settings(
+      crossScalaVersions := bin212 ++ bin213,
       buildInfoKeys += BuildInfoKey("scalaJSVersion", scalaJSVersion),
       publishArtifact := false,
       publishLocal := {}

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,8 @@ lazy val root = Project("scalac-scoverage", file("."))
     runtimeJSDOMTest,
     reporter,
     domain,
-    serializer
+    serializer,
+    buildInfo
   )
 
 lazy val runtime = CrossProject(

--- a/build.sbt
+++ b/build.sbt
@@ -147,7 +147,8 @@ lazy val runtimeJSDOMTest =
 
 lazy val plugin =
   project
-    .dependsOn(runtimeJVM % Test)
+    // we need both runtimes compiled prior to running tests
+    .dependsOn(runtimeJVM % Test, runtimeJS % Test)
     .settings(
       name := "scalac-scoverage-plugin",
       crossTarget := target.value / s"scala-${scalaVersion.value}",

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,10 @@ lazy val plugin =
       crossTarget := target.value / s"scala-${scalaVersion.value}",
       crossScalaVersions := bin212 ++ bin213,
       crossVersion := CrossVersion.full,
-      libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+      libraryDependencies ++= Seq(
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+        "org.scala-js" %% "scalajs-compiler" % scalaJSVersion % Test cross CrossVersion.full
+      ),
       sharedSettings
     )
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,10 @@ lazy val plugin =
       crossTarget := target.value / s"scala-${scalaVersion.value}",
       crossScalaVersions := bin212 ++ bin213,
       crossVersion := CrossVersion.full,
-      libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+      libraryDependencies ++= Seq(
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+        "org.scala-js" %% "scalajs-compiler" % scalaJSVersion % Test cross CrossVersion.full
+      ),
       sharedSettings
     )
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ lazy val plugin =
     .settings(
       Test / unmanagedSourceDirectories += (Test / sourceDirectory).value / "scala-2.12+"
     )
-    .dependsOn(domain, reporter % "test->compile", serializer)
+    .dependsOn(domain, reporter % "test->compile", serializer, buildInfo % Test)
 
 lazy val reporter =
   project
@@ -181,6 +181,15 @@ lazy val reporter =
       crossScalaVersions := Seq(defaultScala212, defaultScala213, defaultScala3)
     )
     .dependsOn(domain, serializer)
+
+lazy val buildInfo =
+  project
+    .settings(
+      buildInfoKeys += BuildInfoKey("scalaJSVersion", scalaJSVersion),
+      publishArtifact := false,
+      publishLocal := {}
+    )
+    .enablePlugins(BuildInfoPlugin)
 
 lazy val domain =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,8 @@ lazy val plugin =
       crossVersion := CrossVersion.full,
       libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
-        "org.scala-js" %% "scalajs-compiler" % scalaJSVersion % Test cross CrossVersion.full
+        "org.scala-js" %% "scalajs-compiler" % scalaJSVersion % Test cross CrossVersion.full,
+        "org.scala-js" %% "scalajs-library" % scalaJSVersion % Test
       ),
       sharedSettings
     )

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -10,6 +10,7 @@ import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.transform.Transform
 import scala.tools.nsc.transform.TypingTransformers
+import scala.util.control.NonFatal
 
 import scoverage.domain.Coverage
 import scoverage.domain.Statement
@@ -102,7 +103,7 @@ class ScoverageInstrumentationComponent(
     try {
       rootMirror.getClassIfDefined("scala.scalajs.js.Any") != NoSymbol
     } catch {
-      case _: Throwable => false
+      case NonFatal(_) => false
     }
   }
 

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -99,7 +99,7 @@ class ScoverageInstrumentationComponent(
   private var options: ScoverageOptions = ScoverageOptions.default()
   private var coverageFilter: CoverageFilter = AllCoverageFilter
 
-  private val isScalaJsEnabled: Boolean = {
+  private lazy val isScalaJsEnabled: Boolean = {
     try {
       rootMirror.getClassIfDefined("scala.scalajs.js.Any") != NoSymbol
     } catch {

--- a/plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
+++ b/plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
@@ -16,6 +16,6 @@ class PluginCoverageScalaJsTest extends FunSuite with MacroSupport {
         |}""".stripMargin
     )
     assert(!compiler.reporter.hasErrors)
-    compiler.assertNMeasuredStatements(4)
+    compiler.assertNMeasuredStatements(2)
   }
 }

--- a/plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
+++ b/plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
@@ -7,7 +7,7 @@ import munit.FunSuite
 class PluginCoverageScalaJsTest extends FunSuite with MacroSupport {
 
   test("scoverage should ignore default undefined parameter") {
-    val compiler = ScoverageCompiler.default
+    val compiler = ScoverageCompiler.defaultJS
     compiler.compileCodeSnippet(
       """import scala.scalajs.js
         |

--- a/plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
+++ b/plugin/src/test/scala/scoverage/PluginCoverageScalaJsTest.scala
@@ -6,7 +6,7 @@ import munit.FunSuite
   */
 class PluginCoverageScalaJsTest extends FunSuite with MacroSupport {
 
-  test("scoverage should ignore default undefined parameter".ignore) {
+  test("scoverage should ignore default undefined parameter") {
     val compiler = ScoverageCompiler.default
     compiler.compileCodeSnippet(
       """import scala.scalajs.js

--- a/plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -55,7 +55,7 @@ private[scoverage] object ScoverageCompiler {
     new ScoverageCompiler(settings, reporter)
   }
 
-  def defaultScalaJs: ScoverageCompiler = {
+  def defaultJS: ScoverageCompiler = {
     val reporter = new scala.tools.nsc.reporters.ConsoleReporter(jsSettings)
     new ScoverageCompiler(jsSettings, reporter)
   }
@@ -71,9 +71,7 @@ private[scoverage] object ScoverageCompiler {
   }
 
   private def getScalaJsJars: List[File] = {
-    List(
-      findJar("org.scala-lang", "scala-compiler", ScalaVersion),
-      findJar("org.scala-lang", "scala-reflect", ScalaVersion),
+    getScalaJars ++ List(
       findJar(
         "org.scala-js",
         s"scalajs-compiler_$ScalaVersion",
@@ -81,7 +79,7 @@ private[scoverage] object ScoverageCompiler {
       ),
       findJar(
         "org.scala-js",
-        s"scalajs-library_$ScalaVersion",
+        s"scalajs-library_$ShortScalaVersion",
         BuildInfo.scalaJSVersion
       )
     )

--- a/plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -11,6 +11,7 @@ import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.transform.Transform
 import scala.tools.nsc.transform.TypingTransformers
 
+import buildinfo.BuildInfo
 import scoverage.reporter.IOUtils
 
 private[scoverage] object ScoverageCompiler {
@@ -24,9 +25,17 @@ private[scoverage] object ScoverageCompiler {
   def classPath: Seq[String] =
     getScalaJars.map(
       _.getAbsolutePath
-    ) :+ sbtCompileDir.getAbsolutePath :+ runtimeClasses.getAbsolutePath
+    ) :+ sbtCompileDir.getAbsolutePath :+ runtimeClasses("jvm").getAbsolutePath
 
-  def settings: Settings = {
+  def jsClassPath: Seq[String] =
+    getScalaJsJars.map(
+      _.getAbsolutePath
+    ) :+ sbtCompileDir.getAbsolutePath :+ runtimeClasses("js").getAbsolutePath
+
+  def settings: Settings = settings(classPath)
+  def jsSettings: Settings = settings(jsClassPath)
+
+  def settings(classPath: Seq[String]): Settings = {
     val s = new scala.tools.nsc.Settings
     s.Xprint.value = List("all", "_")
     s.deprecation.value = true
@@ -46,6 +55,11 @@ private[scoverage] object ScoverageCompiler {
     new ScoverageCompiler(settings, reporter)
   }
 
+  def defaultScalaJs: ScoverageCompiler = {
+    val reporter = new scala.tools.nsc.reporters.ConsoleReporter(jsSettings)
+    new ScoverageCompiler(jsSettings, reporter)
+  }
+
   def locationCompiler: LocationCompiler = {
     val reporter = new scala.tools.nsc.reporters.ConsoleReporter(settings)
     new LocationCompiler(settings, reporter)
@@ -54,6 +68,23 @@ private[scoverage] object ScoverageCompiler {
   private def getScalaJars: List[File] = {
     val scalaJars = List("scala-compiler", "scala-library", "scala-reflect")
     scalaJars.map(findScalaJar)
+  }
+
+  private def getScalaJsJars: List[File] = {
+    List(
+      findJar("org.scala-lang", "scala-compiler", ScalaVersion),
+      findJar("org.scala-lang", "scala-reflect", ScalaVersion),
+      findJar(
+        "org.scala-js",
+        s"scalajs-compiler_$ScalaVersion",
+        BuildInfo.scalaJSVersion
+      ),
+      findJar(
+        "org.scala-js",
+        s"scalajs-library_$ScalaVersion",
+        BuildInfo.scalaJSVersion
+      )
+    )
   }
 
   private def sbtCompileDir: File = {
@@ -67,20 +98,28 @@ private[scoverage] object ScoverageCompiler {
     dir
   }
 
-  private def runtimeClasses: File = new File(
-    s"./runtime/jvm/target/scala-$ScalaVersion/classes"
+  private def runtimeClasses(platform: String): File = new File(
+    s"./runtime/$platform/target/scala-$ScalaVersion/classes"
   )
 
   private def findScalaJar(artifactId: String): File =
-    findIvyJar("org.scala-lang", artifactId, ScalaVersion)
-      .orElse(findCoursierJar(artifactId, ScalaVersion))
+    findJar("org.scala-lang", artifactId, ScalaVersion)
+
+  private def findJar(
+      groupId: String,
+      artifactId: String,
+      version: String
+  ): File =
+    findIvyJar(groupId, artifactId, version)
+      .orElse(findCoursierJar(groupId, artifactId, version))
       .getOrElse {
         throw new FileNotFoundException(
-          s"Could not locate $artifactId/$ScalaVersion"
+          s"Could not locate $groupId:$artifactId:$version"
         )
       }
 
   private def findCoursierJar(
+      groupId: String,
       artifactId: String,
       version: String
   ): Option[File] = {
@@ -89,9 +128,10 @@ private[scoverage] object ScoverageCompiler {
       ".cache/coursier", // Linux
       "Library/Caches/Coursier", // MacOSX
       "AppData/Local/Coursier/cache" // Windows
-    ).map(loc =>
-      s"$userHome/$loc/v1/https/repo1.maven.org/maven2/org/scala-lang/$artifactId/$version/$artifactId-$version.jar"
-    )
+    ).map { loc =>
+      val gid = groupId.replace('.', '/')
+      s"$userHome/$loc/v1/https/repo1.maven.org/maven2/$gid/$artifactId/$version/$artifactId-$version.jar"
+    }
     jarPaths.map(new File(_)).find(_.exists())
   }
 

--- a/plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -33,7 +33,12 @@ private[scoverage] object ScoverageCompiler {
     ) :+ sbtCompileDir.getAbsolutePath :+ runtimeClasses("js").getAbsolutePath
 
   def settings: Settings = settings(classPath)
-  def jsSettings: Settings = settings(jsClassPath)
+
+  def jsSettings: Settings = {
+    val s = settings(jsClassPath)
+    s.plugin.value = List(getScalaJsCompilerJar.getAbsolutePath)
+    s
+  }
 
   def settings(classPath: Seq[String]): Settings = {
     val s = new scala.tools.nsc.Settings
@@ -70,20 +75,18 @@ private[scoverage] object ScoverageCompiler {
     scalaJars.map(findScalaJar)
   }
 
-  private def getScalaJsJars: List[File] = {
-    getScalaJars ++ List(
-      findJar(
-        "org.scala-js",
-        s"scalajs-compiler_$ScalaVersion",
-        BuildInfo.scalaJSVersion
-      ),
-      findJar(
-        "org.scala-js",
-        s"scalajs-library_$ShortScalaVersion",
-        BuildInfo.scalaJSVersion
-      )
-    )
-  }
+  private def getScalaJsJars: List[File] =
+    findJar(
+      "org.scala-js",
+      s"scalajs-library_$ShortScalaVersion",
+      BuildInfo.scalaJSVersion
+    ) :: getScalaJars
+
+  private def getScalaJsCompilerJar: File = findJar(
+    "org.scala-js",
+    s"scalajs-compiler_$ScalaVersion",
+    BuildInfo.scalaJSVersion
+  )
 
   private def sbtCompileDir: File = {
     val dir = new File(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+
 libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0"


### PR DESCRIPTION
This PR re-enables the `PluginCoverageScalaJsTest` that is currently being ignored. ~~Fortunately, it still passes :)~~

Fixes https://github.com/scoverage/scalac-scoverage-plugin/issues/447.