### PR TITLE
Make `isScalaJsEnabled` a `lazy val`

### DIFF
--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -98,7 +98,7 @@ class ScoverageInstrumentationComponent(
   private var options: ScoverageOptions = ScoverageOptions.default()
   private var coverageFilter: CoverageFilter = AllCoverageFilter
 
-  private val isScalaJsEnabled: Boolean = {
+  private lazy val isScalaJsEnabled: Boolean = {
     try {
       rootMirror.getClassIfDefined("scala.scalajs.js.Any") != NoSymbol
     } catch {


### PR DESCRIPTION
Fixes https://github.com/scoverage/scalac-scoverage-plugin/issues/447. This change is extracted out of https://github.com/scoverage/scalac-scoverage-plugin/pull/464, which understandably may take a while to review.

But the fix by itself is innocent enough even without proper tests in place, and would help unblock scoverage on Scala.js projects 🙏 