### PR TITLE
Publish native runtime, fix JSDOM CI setup...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
-      - name: Install JSDOM
-        run: npm install
-
       - name: run tests
         run: sbt ++${{ matrix.scala.version }} plugin/test
 
@@ -63,6 +60,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+
+      - name: Install JSDOM
+        run: npm install
+        if: matrix.module == 'runtimeJSDOMTest'
 
       - name: run tests
         run: sbt +${{ matrix.module }}/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest' ]
         java: ['8', '17' ]
-        module: ['runtime', 'runtimeJS', 'reporter', 'domain', 'serializer']
+        module: ['runtime', 'runtimeJS', 'runtimeNative', 'reporter', 'domain', 'serializer']
     steps:
       - name: checkout the repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest' ]
         java: ['8', '17' ]
-        module: ['runtime', 'runtimeJS', 'runtimeNative', 'reporter', 'domain', 'serializer']
+        module: ['runtime', 'runtimeJS', 'runtimeJSDOMTest', 'runtimeNative', 'reporter', 'domain', 'serializer']
     steps:
       - name: checkout the repo
         uses: actions/checkout@v3

--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,7 @@ lazy val root = Project("scalac-scoverage", file("."))
     plugin,
     runtime.jvm,
     runtime.js,
+    runtime.native,
     runtimeJSDOMTest,
     reporter,
     domain,
@@ -109,7 +110,7 @@ lazy val root = Project("scalac-scoverage", file("."))
 lazy val runtime = CrossProject(
   "runtime",
   file("runtime")
-)(JVMPlatform, JSPlatform)
+)(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Full)
   .withoutSuffixFor(JVMPlatform)
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,9 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
+
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.4")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
+
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/runtime/native/src/main/scala/scoverage/Platform.scala
+++ b/runtime/native/src/main/scala/scoverage/Platform.scala
@@ -1,0 +1,31 @@
+package scoverage
+
+import java.io.{File => SupportFile}
+import java.io.{FileFilter => SupportFileFilter}
+import java.io.{FileWriter => SupportFileWriter}
+
+import scala.collection.mutable.HashMap
+import scala.io.{Source => SupportSource}
+
+object Platform {
+ type ThreadSafeMap[A, B] = HashMap[A, B]
+  lazy val ThreadSafeMap = HashMap
+
+  type File = SupportFile
+  type FileWriter = SupportFileWriter
+  type FileFilter = SupportFileFilter
+
+  lazy val Source = SupportSource
+
+  def insecureRandomUUID() = {
+    import scala.util.Random
+    var msb = Random.nextLong()
+    var lsb = Random.nextLong()
+    msb &= 0xffffffffffff0fffL // clear version
+    msb |= 0x0000000000004000L // set to version 4
+    lsb &= 0x3fffffffffffffffL // clear variant
+    lsb |= 0x8000000000000000L // set to IETF variant
+    new java.util.UUID(msb, lsb)
+  }
+
+}

--- a/runtime/native/src/main/scala/scoverage/Platform.scala
+++ b/runtime/native/src/main/scala/scoverage/Platform.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable.HashMap
 import scala.io.{Source => SupportSource}
 
 object Platform {
- type ThreadSafeMap[A, B] = HashMap[A, B]
+  type ThreadSafeMap[A, B] = HashMap[A, B]
   lazy val ThreadSafeMap = HashMap
 
   type File = SupportFile


### PR DESCRIPTION
It's a sort of hybrid between the JVM and JS runtimes:
- we can use `java.io` and `scala.io` APIs
- single-threaded, so we use a `HashMap` instead of `TrieMap`
- not sure the future of `randomUUID()`, so easier to inline for long-term compatibility.
  https://github.com/scala-native/scala-native/issues/2600

Edit: ok, this PR also fixes the botched JSDOM CI setup