### PR TITLE
Refresh the excluded implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ Any matched classes will not be instrumented or included in the coverage report.
 
 You can also exclude files from being considered for instrumentation.
 
-    -P:scoverage:excludedFiles:.*\/two\/GoodCoverage\.scala;.*\/three\/.*
+    -P:scoverage:excludedFiles:.*\/two\/GoodCoverage;.*\/three\/.*
 
-Note: This only works for Scala2. Right now Scala3 does not support
+Note: The `.scala` file extension needs to be omitted from the filename, if one is given.
+
+Note: These two options only work for Scala2. Right now Scala3 does not support
 a way to exclude packages or files from being instrumented.
 
 You can also mark sections of code with comments like:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Search for scalac-scoverage-plugin.
 #### Excluding code from coverage stats
 
 You can exclude whole classes or packages by name. Pass a semicolon separated
-list of regexes to the 'excludedPackages' option.
+list of regexes to the `excludedPackages` option.
 
 For example:
 
@@ -97,6 +97,13 @@ For example:
 The regular expressions are matched against the fully qualified class name, and must match the entire string to take effect.
 
 Any matched classes will not be instrumented or included in the coverage report.
+
+You can also exclude files from being considered for instrumentation.
+
+    -P:scoverage:excludedFiles:.*\/two\/GoodCoverage\.scala;.*\/three\/.*
+
+Note: This only works for Scala2. Right now Scala3 does not support
+a way to exclude packages or files from being instrumented.
 
 You can also mark sections of code with comments like:
 

--- a/plugin/src/main/scala/scoverage/CoverageFilter.scala
+++ b/plugin/src/main/scala/scoverage/CoverageFilter.scala
@@ -32,9 +32,12 @@ class RegexCoverageFilter(
     excludedSymbols: Seq[String],
     reporter: Reporter
 ) extends CoverageFilter {
-  if (excludedPackages.nonEmpty) reporter.echo(s"scoverage excludedPackages: ${excludedPackages}")
-  if (excludedFiles.nonEmpty) reporter.echo(s"scoverage excludedFiles: ${excludedFiles}")
-  if (excludedSymbols.nonEmpty) reporter.echo(s"scoverage excludedSymbols: ${excludedSymbols}")
+  if (excludedPackages.nonEmpty)
+    reporter.echo(s"scoverage excludedPackages: ${excludedPackages}")
+  if (excludedFiles.nonEmpty)
+    reporter.echo(s"scoverage excludedFiles: ${excludedFiles}")
+  if (excludedSymbols.nonEmpty)
+    reporter.echo(s"scoverage excludedSymbols: ${excludedSymbols}")
 
   val excludedClassNamePatterns = excludedPackages.map(_.r.pattern)
   val excludedFilePatterns = excludedFiles.map(_.r.pattern)

--- a/plugin/src/main/scala/scoverage/CoverageFilter.scala
+++ b/plugin/src/main/scala/scoverage/CoverageFilter.scala
@@ -28,8 +28,13 @@ object AllCoverageFilter extends CoverageFilter {
 class RegexCoverageFilter(
     excludedPackages: Seq[String],
     excludedFiles: Seq[String],
-    excludedSymbols: Seq[String]
+    excludedSymbols: Seq[String],
+    reporter: scala.tools.nsc.reporters.Reporter
+
 ) extends CoverageFilter {
+  reporter.echo(s"scoverage excludedPackages: ${excludedPackages}")
+  reporter.echo(s"scoverage excludedFiles: ${excludedFiles}")
+  reporter.echo(s"scoverage excludedSymbols: ${excludedSymbols}")
 
   val excludedClassNamePatterns = excludedPackages.map(_.r.pattern)
   val excludedFilePatterns = excludedFiles.map(_.r.pattern)
@@ -56,7 +61,7 @@ class RegexCoverageFilter(
 
   override def isFileIncluded(file: SourceFile): Boolean = {
     def isFileMatch(file: SourceFile) = excludedFilePatterns.exists(
-      _.matcher(file.path.replace(".scala", "")).matches
+      _.matcher(file.path).matches
     )
     excludedFilePatterns.isEmpty || !isFileMatch(file)
   }

--- a/plugin/src/main/scala/scoverage/CoverageFilter.scala
+++ b/plugin/src/main/scala/scoverage/CoverageFilter.scala
@@ -32,9 +32,9 @@ class RegexCoverageFilter(
     excludedSymbols: Seq[String],
     reporter: Reporter
 ) extends CoverageFilter {
-  reporter.echo(s"scoverage excludedPackages: ${excludedPackages}")
-  reporter.echo(s"scoverage excludedFiles: ${excludedFiles}")
-  reporter.echo(s"scoverage excludedSymbols: ${excludedSymbols}")
+  if (excludedPackages.nonEmpty) reporter.echo(s"scoverage excludedPackages: ${excludedPackages}")
+  if (excludedFiles.nonEmpty) reporter.echo(s"scoverage excludedFiles: ${excludedFiles}")
+  if (excludedSymbols.nonEmpty) reporter.echo(s"scoverage excludedSymbols: ${excludedSymbols}")
 
   val excludedClassNamePatterns = excludedPackages.map(_.r.pattern)
   val excludedFilePatterns = excludedFiles.map(_.r.pattern)
@@ -61,7 +61,7 @@ class RegexCoverageFilter(
 
   override def isFileIncluded(file: SourceFile): Boolean = {
     def isFileMatch(file: SourceFile) = excludedFilePatterns.exists(
-      _.matcher(file.path).matches
+      _.matcher(file.path.replace(".scala", "")).matches
     )
     excludedFilePatterns.isEmpty || !isFileMatch(file)
   }

--- a/plugin/src/main/scala/scoverage/CoverageFilter.scala
+++ b/plugin/src/main/scala/scoverage/CoverageFilter.scala
@@ -3,6 +3,7 @@ package scoverage
 import scala.collection.mutable
 import scala.reflect.internal.util.Position
 import scala.reflect.internal.util.SourceFile
+import scala.tools.nsc.reporters.Reporter
 import scala.util.matching.Regex
 
 /** Methods related to filtering the instrumentation and coverage.
@@ -29,7 +30,7 @@ class RegexCoverageFilter(
     excludedPackages: Seq[String],
     excludedFiles: Seq[String],
     excludedSymbols: Seq[String],
-    reporter: scala.tools.nsc.reporters.Reporter
+    reporter: Reporter
 
 ) extends CoverageFilter {
   reporter.echo(s"scoverage excludedPackages: ${excludedPackages}")

--- a/plugin/src/main/scala/scoverage/CoverageFilter.scala
+++ b/plugin/src/main/scala/scoverage/CoverageFilter.scala
@@ -31,7 +31,6 @@ class RegexCoverageFilter(
     excludedFiles: Seq[String],
     excludedSymbols: Seq[String],
     reporter: Reporter
-
 ) extends CoverageFilter {
   reporter.echo(s"scoverage excludedPackages: ${excludedPackages}")
   reporter.echo(s"scoverage excludedFiles: ${excludedFiles}")

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -232,7 +232,8 @@ class ScoverageInstrumentationComponent(
       safeSource(tree) match {
         case None =>
           reporter.warning(
-            NoPosition, s"Could not instrument [${tree.getClass.getSimpleName}/${tree.symbol}]."
+            NoPosition,
+            s"Could not instrument [${tree.getClass.getSimpleName}/${tree.symbol}]."
           )
           tree
         case Some(source) =>

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -232,7 +232,7 @@ class ScoverageInstrumentationComponent(
       safeSource(tree) match {
         case None =>
           reporter.warning(
-            NoPosition(), s"Could not instrument [${tree.getClass.getSimpleName}/${tree.symbol}]."
+            NoPosition, s"Could not instrument [${tree.getClass.getSimpleName}/${tree.symbol}]."
           )
           tree
         case Some(source) =>

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -112,7 +112,8 @@ class ScoverageInstrumentationComponent(
     coverageFilter = new RegexCoverageFilter(
       options.excludedPackages,
       options.excludedFiles,
-      options.excludedSymbols
+      options.excludedSymbols,
+      reporter
     )
     new File(options.dataDir).mkdirs() // ensure data directory is created
   }
@@ -230,8 +231,8 @@ class ScoverageInstrumentationComponent(
     ): Tree = {
       safeSource(tree) match {
         case None =>
-          reporter.echo(
-            s"[warn] Could not instrument [${tree.getClass.getSimpleName}/${tree.symbol}]. No pos."
+          reporter.warning(
+            NoPosition(), s"Could not instrument [${tree.getClass.getSimpleName}/${tree.symbol}]."
           )
           tree
         case Some(source) =>
@@ -361,7 +362,7 @@ class ScoverageInstrumentationComponent(
       Location.fromGlobal(global)(t) match {
         case Some(loc) => this.location = loc
         case _ =>
-          reporter.warning(t.pos, s"[warn] Cannot update location for $t")
+          reporter.warning(t.pos, s"Cannot update location for $t")
       }
     }
 

--- a/plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
+++ b/plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
@@ -70,7 +70,7 @@ class RegexCoverageFilterTest extends FunSuite {
   test("should exclude by filename") {
     val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
     assert(
-      !new RegexCoverageFilter(Nil, Seq("sammy\\.scala"), Nil, reporter)
+      !new RegexCoverageFilter(Nil, Seq("sammy"), Nil, reporter)
         .isFileIncluded(file)
     )
   }

--- a/plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
+++ b/plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
@@ -14,7 +14,9 @@ class RegexCoverageFilterTest extends FunSuite {
   val reporter = new ConsoleReporter(new Settings())
 
   test("isClassIncluded should return true for empty excludes") {
-    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isClassIncluded("x"))
+    assert(
+      new RegexCoverageFilter(Nil, Nil, Nil, reporter).isClassIncluded("x")
+    )
   }
 
   test("should not crash for empty input") {
@@ -60,7 +62,9 @@ class RegexCoverageFilterTest extends FunSuite {
 
   test("isFileIncluded should return true for empty excludes") {
     val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
-    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isFileIncluded(file))
+    assert(
+      new RegexCoverageFilter(Nil, Nil, Nil, reporter).isFileIncluded(file)
+    )
   }
 
   test("should exclude by filename") {
@@ -90,11 +94,15 @@ class RegexCoverageFilterTest extends FunSuite {
   val options = ScoverageOptions.default()
 
   test("isSymbolIncluded should return true for empty excludes") {
-    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isSymbolIncluded("x"))
+    assert(
+      new RegexCoverageFilter(Nil, Nil, Nil, reporter).isSymbolIncluded("x")
+    )
   }
 
   test("should not crash for empty input") {
-    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isSymbolIncluded(""))
+    assert(
+      new RegexCoverageFilter(Nil, Nil, Nil, reporter).isSymbolIncluded("")
+    )
   }
 
   test("should exclude scoverage -> scoverage") {

--- a/plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
+++ b/plugin/src/test/scala/scoverage/RegexCoverageFilterTest.scala
@@ -4,50 +4,54 @@ import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.internal.util.NoFile
 import scala.reflect.internal.util.SourceFile
 import scala.reflect.io.VirtualFile
+import scala.tools.nsc.reporters.ConsoleReporter
+import scala.tools.nsc.Settings
 
 import munit.FunSuite
 
 class RegexCoverageFilterTest extends FunSuite {
 
+  val reporter = new ConsoleReporter(new Settings())
+
   test("isClassIncluded should return true for empty excludes") {
-    assert(new RegexCoverageFilter(Nil, Nil, Nil).isClassIncluded("x"))
+    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isClassIncluded("x"))
   }
 
   test("should not crash for empty input") {
-    assert(new RegexCoverageFilter(Nil, Nil, Nil).isClassIncluded(""))
+    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isClassIncluded(""))
   }
 
   test("should exclude scoverage -> scoverage") {
     assert(
-      !new RegexCoverageFilter(Seq("scoverage"), Nil, Nil)
+      !new RegexCoverageFilter(Seq("scoverage"), Nil, Nil, reporter)
         .isClassIncluded("scoverage")
     )
   }
 
   test("should include scoverage -> scoverageeee") {
     assert(
-      new RegexCoverageFilter(Seq("scoverage"), Nil, Nil)
+      new RegexCoverageFilter(Seq("scoverage"), Nil, Nil, reporter)
         .isClassIncluded("scoverageeee")
     )
   }
 
   test("should exclude scoverage* -> scoverageeee") {
     assert(
-      !new RegexCoverageFilter(Seq("scoverage*"), Nil, Nil)
+      !new RegexCoverageFilter(Seq("scoverage*"), Nil, Nil, reporter)
         .isClassIncluded("scoverageeee")
     )
   }
 
   test("should include eee -> scoverageeee") {
     assert(
-      new RegexCoverageFilter(Seq("eee"), Nil, Nil)
+      new RegexCoverageFilter(Seq("eee"), Nil, Nil, reporter)
         .isClassIncluded("scoverageeee")
     )
   }
 
   test("should exclude .*eee -> scoverageeee") {
     assert(
-      !new RegexCoverageFilter(Seq(".*eee"), Nil, Nil)
+      !new RegexCoverageFilter(Seq(".*eee"), Nil, Nil, reporter)
         .isClassIncluded("scoverageeee")
     )
   }
@@ -56,13 +60,13 @@ class RegexCoverageFilterTest extends FunSuite {
 
   test("isFileIncluded should return true for empty excludes") {
     val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
-    assert(new RegexCoverageFilter(Nil, Nil, Nil).isFileIncluded(file))
+    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isFileIncluded(file))
   }
 
   test("should exclude by filename") {
     val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
     assert(
-      !new RegexCoverageFilter(Nil, Seq("sammy"), Nil)
+      !new RegexCoverageFilter(Nil, Seq("sammy\\.scala"), Nil, reporter)
         .isFileIncluded(file)
     )
   }
@@ -70,7 +74,7 @@ class RegexCoverageFilterTest extends FunSuite {
   test("should exclude by regex wildcard") {
     val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
     assert(
-      !new RegexCoverageFilter(Nil, Seq("sam.*"), Nil)
+      !new RegexCoverageFilter(Nil, Seq("sam.*"), Nil, reporter)
         .isFileIncluded(file)
     )
   }
@@ -78,7 +82,7 @@ class RegexCoverageFilterTest extends FunSuite {
   test("should not exclude non matching regex") {
     val file = new BatchSourceFile(abstractFile, Array.emptyCharArray)
     assert(
-      new RegexCoverageFilter(Nil, Seq("qweqeqwe"), Nil)
+      new RegexCoverageFilter(Nil, Seq("qweqeqwe"), Nil, reporter)
         .isFileIncluded(file)
     )
   }
@@ -86,61 +90,61 @@ class RegexCoverageFilterTest extends FunSuite {
   val options = ScoverageOptions.default()
 
   test("isSymbolIncluded should return true for empty excludes") {
-    assert(new RegexCoverageFilter(Nil, Nil, Nil).isSymbolIncluded("x"))
+    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isSymbolIncluded("x"))
   }
 
   test("should not crash for empty input") {
-    assert(new RegexCoverageFilter(Nil, Nil, Nil).isSymbolIncluded(""))
+    assert(new RegexCoverageFilter(Nil, Nil, Nil, reporter).isSymbolIncluded(""))
   }
 
   test("should exclude scoverage -> scoverage") {
     assert(
-      !new RegexCoverageFilter(Nil, Nil, Seq("scoverage"))
+      !new RegexCoverageFilter(Nil, Nil, Seq("scoverage"), reporter)
         .isSymbolIncluded("scoverage")
     )
   }
 
   test("should include scoverage -> scoverageeee") {
     assert(
-      new RegexCoverageFilter(Nil, Nil, Seq("scoverage"))
+      new RegexCoverageFilter(Nil, Nil, Seq("scoverage"), reporter)
         .isSymbolIncluded("scoverageeee")
     )
   }
   test("should exclude scoverage* -> scoverageeee") {
     assert(
-      !new RegexCoverageFilter(Nil, Nil, Seq("scoverage*"))
+      !new RegexCoverageFilter(Nil, Nil, Seq("scoverage*"), reporter)
         .isSymbolIncluded("scoverageeee")
     )
   }
 
   test("should include eee -> scoverageeee") {
     assert(
-      new RegexCoverageFilter(Nil, Nil, Seq("eee"))
+      new RegexCoverageFilter(Nil, Nil, Seq("eee"), reporter)
         .isSymbolIncluded("scoverageeee")
     )
   }
 
   test("should exclude .*eee -> scoverageeee") {
     assert(
-      !new RegexCoverageFilter(Nil, Nil, Seq(".*eee"))
+      !new RegexCoverageFilter(Nil, Nil, Seq(".*eee"), reporter)
         .isSymbolIncluded("scoverageeee")
     )
   }
   test("should exclude scala.reflect.api.Exprs.Expr") {
     assert(
-      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
+      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols, reporter)
         .isSymbolIncluded("scala.reflect.api.Exprs.Expr")
     )
   }
   test("should exclude scala.reflect.macros.Universe.Tree") {
     assert(
-      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
+      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols, reporter)
         .isSymbolIncluded("scala.reflect.macros.Universe.Tree")
     )
   }
   test("should exclude scala.reflect.api.Trees.Tree") {
     assert(
-      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols)
+      !new RegexCoverageFilter(Nil, Nil, options.excludedSymbols, reporter)
         .isSymbolIncluded("scala.reflect.api.Trees.Tree")
     )
   }
@@ -158,7 +162,7 @@ class RegexCoverageFilterTest extends FunSuite {
         |8
         """.stripMargin
 
-    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil, reporter)
       .getExcludedLineNumbers(mockSourceFile(file))
     assertEquals(numbers, List.empty)
   }
@@ -182,7 +186,7 @@ class RegexCoverageFilterTest extends FunSuite {
         |16
         """.stripMargin
 
-    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil, reporter)
       .getExcludedLineNumbers(mockSourceFile(file))
     assertEquals(numbers, List(Range(4, 9), Range(12, 14)))
   }
@@ -205,7 +209,7 @@ class RegexCoverageFilterTest extends FunSuite {
         |15
         """.stripMargin
 
-    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil, reporter)
       .getExcludedLineNumbers(mockSourceFile(file))
     assertEquals(numbers, List(Range(4, 9), Range(12, 16)))
   }
@@ -228,7 +232,7 @@ class RegexCoverageFilterTest extends FunSuite {
         |15
         """.stripMargin
 
-    val numbers = new RegexCoverageFilter(Nil, Nil, Nil)
+    val numbers = new RegexCoverageFilter(Nil, Nil, Nil, reporter)
       .getExcludedLineNumbers(mockSourceFile(file))
     assertEquals(numbers, List(Range(4, 9), Range(12, 16)))
   }

--- a/reporter/src/test/scala/scoverage/reporter/IOUtilsTest.scala
+++ b/reporter/src/test/scala/scoverage/reporter/IOUtilsTest.scala
@@ -6,7 +6,6 @@ import java.util.UUID
 
 import munit.FunSuite
 import scoverage.domain.Constants
-import scoverage.reporter.IOUtils
 
 /** @author Stephen Samuel */
 class IOUtilsTest extends FunSuite {


### PR DESCRIPTION
Hi @ckipp01,

my name is Roland Tritsch. Thanks for all the hard work on making scoverage work (again) for Scala3.

I also need this and will spend some time on this over the next couple of weeks and will start to send PR's your way.

I will try to keep the PR's small. But that also means there will be more of them. Hope that is ok.

The first one/this one clarifies that the excludePackages/Files only works for Scala2.

Will also send a PR on `sbt-scoverage` to add a test for this.

I need this functionality to work for Scala3, but would assume that it will be a while before dotty supports this out of the box.

Therefore I am thinking to add a `coverageExclude` task to `sbt-scoverage` that will rewrite/cleanup the `scoverage.coverage` file (remove the excluded packages, classes, files).

This is can then be removed again as soon as dotty will support a comparable exclude capability.

Agreed?