### PR TITLE
Use scala-xml 2.1.0 on all Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,16 +158,7 @@ lazy val reporter =
   project
     .settings(
       name := "scalac-scoverage-reporter",
-      libraryDependencies += CrossVersion
-        .partialVersion(
-          scalaVersion.value
-        )
-        .map {
-          // Lock this for 2.12 to align with the compiler
-          // https://github.com/scala/scala/pull/9743
-          case ((2, 12)) => "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
-          case _         => "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
-        },
+      libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
       sharedSettings,
       crossScalaVersions := Seq(defaultScala212, defaultScala213, defaultScala3)
     )


### PR DESCRIPTION
As discussed in https://github.com/scoverage/sbt-scoverage/issues/439.