### PR TITLE
Case statements should be counted as branches

### DIFF
--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -213,13 +213,17 @@ class ScoverageInstrumentationComponent(
         }) ++ cases.takeRight(1)
     }
 
-    def transformCases(cases: List[CaseDef], branch: Boolean = false): List[CaseDef] = {
+    def transformCases(
+        cases: List[CaseDef],
+        branch: Boolean = false
+    ): List[CaseDef] = {
       cases.map(c => {
         treeCopy.CaseDef(
           c,
           c.pat,
           process(c.guard),
-          if (branch) instrument(process(c.body), c.body, branch = true) else process(c.body)
+          if (branch) instrument(process(c.body), c.body, branch = true)
+          else process(c.body)
         )
       })
     }
@@ -697,7 +701,11 @@ class ScoverageInstrumentationComponent(
               treeCopy.Match(tree, selector, transformCases(cases))
             else
               // .. but we will if it was a user match
-              treeCopy.Match(tree, process(selector), transformCases(cases, branch = true))
+              treeCopy.Match(
+                tree,
+                process(selector),
+                transformCases(cases, branch = true)
+              )
           }
 
         // a synthetic object is a generated object, such as case class companion

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -213,13 +213,13 @@ class ScoverageInstrumentationComponent(
         }) ++ cases.takeRight(1)
     }
 
-    def transformCases(cases: List[CaseDef]): List[CaseDef] = {
+    def transformCases(cases: List[CaseDef], branch: Boolean = false): List[CaseDef] = {
       cases.map(c => {
         treeCopy.CaseDef(
           c,
           c.pat,
           process(c.guard),
-          process(c.body)
+          if (branch) instrument(process(c.body), c.body, branch = true) else process(c.body)
         )
       })
     }
@@ -392,7 +392,7 @@ class ScoverageInstrumentationComponent(
                       // note: do not transform last case as that is the default handling
                       d.rhs,
                       selector,
-                      transformCases(cases.init) :+ cases.last
+                      transformCases(cases.init, branch = true) :+ cases.last
                     )
                   )
                 case _ =>
@@ -697,7 +697,7 @@ class ScoverageInstrumentationComponent(
               treeCopy.Match(tree, selector, transformCases(cases))
             else
               // .. but we will if it was a user match
-              treeCopy.Match(tree, process(selector), transformCases(cases))
+              treeCopy.Match(tree, process(selector), transformCases(cases, branch = true))
           }
 
         // a synthetic object is a generated object, such as case class companion
@@ -791,7 +791,7 @@ class ScoverageInstrumentationComponent(
           treeCopy.Try(
             tree,
             instrument(process(t), t, branch = true),
-            transformCases(cases),
+            transformCases(cases, branch = true),
             if (f.isEmpty) f else instrument(process(f), f, branch = true)
           )
 

--- a/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -79,9 +79,9 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     assert(!compiler.reporter.hasWarnings)
 
     /** should have the following statements instrumented:
-      * the selector, clause 1
+      * the selector, clause/skip 1
       */
-    compiler.assertNMeasuredStatements(2)
+    compiler.assertNMeasuredStatements(3)
   }
   test("scoverage should instrument match guards") {
     val compiler = ScoverageCompiler.default
@@ -98,7 +98,7 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     /** should have the following statements instrumented:
       * the selector, guard 1, clause 1, guard 2, clause 2, clause 3
       */
-    compiler.assertNMeasuredStatements(6)
+    compiler.assertNMeasuredStatements(9)
   }
 
   test("scoverage should instrument non basic selector") {
@@ -114,7 +114,8 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     // the someValue method entry
     // the selector call
     // case block "yes" literal
-    compiler.assertNMeasuredStatements(3)
+    // skip case block
+    compiler.assertNMeasuredStatements(4)
   }
 
   test("scoverage should instrument conditional selectors in a match") {
@@ -134,7 +135,8 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     // elsep block,
     // elsep literal "2",
     // case block "yes" literal
-    compiler.assertNMeasuredStatements(6)
+    // skip case block "yes" literal
+    compiler.assertNMeasuredStatements(7)
   }
 
   // https://github.com/scoverage/sbt-scoverage/issues/16
@@ -261,8 +263,9 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     assert(!compiler.reporter.hasErrors)
     assert(!compiler.reporter.hasWarnings)
     // should have one statement for each case body
+    // and one statement for each case skipped
     // selector is a constant so would be ignored.
-    compiler.assertNMeasuredStatements(3)
+    compiler.assertNMeasuredStatements(6)
   }
 
   test("plugin should support yields") {


### PR DESCRIPTION
The readme mentions that branch coverage includes if/else, pattern matching, partial functions and try/catch/finally. But currently, it only supports if/else and try/catch/finally. All the  `case` statements  are not covered as branches. This means pattern matching, partial functions, catch blocks and any ad-hoc match statement that functionally acts as an if/else block.

This change follows what was done in the early versions of the repo and instruments the case statements as branches. Since case statements are also used as sentinels, it is necessary to parameterize the `transformCases` helper to distinguish when to actually instrument with branching or not.

This addresses #96 which has been open for quite a while already.