### PR TITLE
Bug Fix: sbt-coveralls: Issue 199: Use relative paths in cobertura.xml file

### DIFF
--- a/reporter/src/main/scala/scoverage/reporter/CoberturaXmlWriter.scala
+++ b/reporter/src/main/scala/scoverage/reporter/CoberturaXmlWriter.scala
@@ -51,7 +51,7 @@ class CoberturaXmlWriter(
 
   def klass(klass: MeasuredClass): Node = {
     <class name={klass.fullClassName}
-           filename={klass.source}
+           filename={relativeSource(klass.source)}
            line-rate={DoubleFormat.twoFractionDigits(klass.statementCoverage)}
            branch-rate={DoubleFormat.twoFractionDigits(klass.branchCoverage)}
            complexity="0">

--- a/reporter/src/main/scala/scoverage/reporter/ScoverageXmlWriter.scala
+++ b/reporter/src/main/scala/scoverage/reporter/ScoverageXmlWriter.scala
@@ -99,7 +99,7 @@ class ScoverageXmlWriter(
 
   private def klass(klass: MeasuredClass): Node = {
     <class name={klass.fullClassName}
-           filename={klass.source}
+           filename={relativeSource(klass.source)}
            statement-count={klass.statementCount.toString}
            statements-invoked={klass.invokedStatementCount.toString}
            statement-rate={klass.statementCoverageFormatted}

--- a/reporter/src/test/scala/scoverage/reporter/CoberturaXmlWriterTest.scala
+++ b/reporter/src/test/scala/scoverage/reporter/CoberturaXmlWriterTest.scala
@@ -101,14 +101,14 @@ class CoberturaXmlWriterTest extends FunSuite {
       ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(
         0
       ) \ "@filename").text,
-      "a.scala"
+      new File("a.scala").getPath()
     )
 
     assertEquals(
       ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(
         1
       ) \ "@filename").text,
-      "a/b.scala"
+      new File("a", "b.scala").getPath()
     )
   }
 

--- a/reporter/src/test/scala/scoverage/reporter/CoberturaXmlWriterTest.scala
+++ b/reporter/src/test/scala/scoverage/reporter/CoberturaXmlWriterTest.scala
@@ -34,6 +34,80 @@ class CoberturaXmlWriterTest extends FunSuite {
   private def canonicalPath(fileName: String) =
     new File(sourceRoot, fileName).getCanonicalPath
 
+  test("cobertura output has relative file path") {
+
+    val dir = tempDir()
+
+    val coverage = Coverage()
+    coverage.add(
+      Statement(
+        Location(
+          "com.sksamuel.scoverage",
+          "A",
+          "com.sksamuel.scoverage.A",
+          ClassType.Object,
+          "create",
+          canonicalPath("a.scala")
+        ),
+        1,
+        2,
+        3,
+        12,
+        "",
+        "",
+        "",
+        false,
+        3
+      )
+    )
+    coverage.add(
+      Statement(
+        Location(
+          "com.sksamuel.scoverage.A",
+          "B",
+          "com.sksamuel.scoverage.A.B",
+          ClassType.Object,
+          "create",
+          canonicalPath("a/b.scala")
+        ),
+        2,
+        2,
+        3,
+        12,
+        "",
+        "",
+        "",
+        false,
+        3
+      )
+    )
+
+    val writer = new CoberturaXmlWriter(sourceRoot, dir, None)
+    writer.write(coverage)
+
+    // Needed to acount for https://github.com/scala/scala-xml/pull/177
+    val customXML: XMLLoader[Elem] = XML.withSAXParser {
+      val factory = SAXParserFactory.newInstance()
+      factory.setFeature(
+        "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+        false
+      )
+      factory.newSAXParser()
+    }
+
+    val xml = customXML.loadFile(fileIn(dir))
+
+    assertEquals(
+      ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(0) \ "@filename").text,
+      "a.scala"
+    )
+
+    assertEquals(
+      ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(1) \ "@filename").text,
+      "a/b.scala"
+    )
+  }
+
   test("cobertura output validates") {
 
     val dir = tempDir()

--- a/reporter/src/test/scala/scoverage/reporter/CoberturaXmlWriterTest.scala
+++ b/reporter/src/test/scala/scoverage/reporter/CoberturaXmlWriterTest.scala
@@ -98,12 +98,16 @@ class CoberturaXmlWriterTest extends FunSuite {
     val xml = customXML.loadFile(fileIn(dir))
 
     assertEquals(
-      ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(0) \ "@filename").text,
+      ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(
+        0
+      ) \ "@filename").text,
       "a.scala"
     )
 
     assertEquals(
-      ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(1) \ "@filename").text,
+      ((xml \\ "coverage" \ "packages" \ "package" \ "classes" \ "class")(
+        1
+      ) \ "@filename").text,
       "a/b.scala"
     )
   }


### PR DESCRIPTION
Hi @ckipp01. Here is the proposed bug-fix for [issue 199 on sbt-coveralls][199].

One way to fix this is to make sure that `Location.source` is NOT using the canonical path, but I do not know what else relies on it.

Means the less risky fix was to use `relativeSource` from the `BaseReportWriter`. This is what the other report writers are doing.

I also tested this with by rebuilding `sbt-scoverage` with a local build of the fixed `scala-scoverage-plugin`. 

[199]: https://github.com/scoverage/sbt-coveralls/issues/199