### PR TITLE
Allow to handle "no source root found" in a custom way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,12 @@ credentials.sbt
 .idea_modules
 *.iml
 
+# VSCode with Metals specific
+.bsp
+.bloop
+.metals
+.vscode
+metals.sbt
+
 # npm specific
 node_modules/

--- a/reporter/src/main/scala/scoverage/reporter/BaseReportWriter.scala
+++ b/reporter/src/main/scala/scoverage/reporter/BaseReportWriter.scala
@@ -2,39 +2,62 @@ package scoverage.reporter
 
 import java.io.File
 
-class BaseReportWriter(
-    sourceDirectories: Seq[File],
+/** Abstract report writer.
+  *
+  * @param sourceRoots list of source directories
+  * @param outputDir directory where to store the reports
+  * @param outputEncoding encoding to use when writing files
+  * @param recoverNoSourceRoot specifies how to handle source paths that are outside of the source roots.
+  */
+abstract class BaseReportWriter(
+    sourceRoots: Seq[File],
     outputDir: File,
-    sourceEncoding: Option[String]
+    outputEncoding: Option[String],
+    recoverNoSourceRoot: BaseReportWriter.PathRecoverer
 ) {
 
   // Source paths in canonical form WITH trailing file separator
   private val formattedSourcePaths: Seq[String] =
-    sourceDirectories
+    sourceRoots
       .filter(_.isDirectory)
-      .map(_.getCanonicalPath + File.separator)
+      .map(_.getCanonicalPath + File.separatorChar)
 
-  /** Converts absolute path to relative one if any of the source directories is it's parent.
-    * If there is no parent directory, the path is returned unchanged (absolute).
+  /** Converts an absolute path to a path relative to the reporter's source directories (aka "source roots").
+    * If the path is not in the source roots, returns None.
     *
     * @param src absolute file path in canonical form
+    * @return `Some(relativePath)` if `src` is in the source roots, else `None`
     */
-  def relativeSource(src: String): String =
+  def relativeSource(src: String): Option[String] =
     relativeSource(src, formattedSourcePaths)
 
-  private def relativeSource(src: String, sourcePaths: Seq[String]): String = {
+  private def relativeSource(
+      src: String,
+      sourceRoots: Seq[String]
+  ): Option[String] = {
     // We need the canonical path for the given src because our formattedSourcePaths are canonical
     val canonicalSrc = new File(src).getCanonicalPath
-    val sourceRoot: Option[String] =
-      sourcePaths.find(sourcePath => canonicalSrc.startsWith(sourcePath))
-    sourceRoot match {
-      case Some(path: String) => canonicalSrc.replace(path, "")
-      case _ =>
-        val fmtSourcePaths: String = sourcePaths.mkString("'", "', '", "'")
-        throw new RuntimeException(
-          s"No source root found for '$canonicalSrc' (source roots: $fmtSourcePaths)"
-        );
-    }
+    sourceRoots
+      .find(root => canonicalSrc.startsWith(root))
+      .map(root => canonicalSrc.substring(root.length))
+      .orElse(recoverNoSourceRoot(new File(canonicalSrc), formattedSourcePaths))
   }
+}
+object BaseReportWriter {
 
+  /** Specifies how to handle source path that are outside of the source roots.
+    * Takes the source path (as a canonical File) and returns:
+    * - `None` to skip the element
+    * - `Some(newPath)` to use `newPath` instead
+    *
+    * The function may of course take additional actions, such as logging a warning,
+    * throwing an error, etc.
+    */
+  type PathRecoverer = (File, Seq[String]) => Option[String]
+
+  /** Throws an exception */
+  def failIfNoSourceRoot(f: File, roots: Seq[String]): Option[String] =
+    throw new RuntimeException(
+      s"No source root found for '${f.getPath}' (source roots: $roots)"
+    )
 }

--- a/reporter/src/main/scala/scoverage/reporter/CoberturaXmlWriter.scala
+++ b/reporter/src/main/scala/scoverage/reporter/CoberturaXmlWriter.scala
@@ -15,11 +15,22 @@ import scoverage.domain.MeasuredPackage
 class CoberturaXmlWriter(
     sourceDirectories: Seq[File],
     outputDir: File,
-    sourceEncoding: Option[String]
-) extends BaseReportWriter(sourceDirectories, outputDir, sourceEncoding) {
+    sourceEncoding: Option[String],
+    recoverNoSourceRoot: BaseReportWriter.PathRecoverer
+) extends BaseReportWriter(
+      sourceDirectories,
+      outputDir,
+      sourceEncoding,
+      recoverNoSourceRoot
+    ) {
 
-  def this(baseDir: File, outputDir: File, sourceEncoding: Option[String]) = {
-    this(Seq(baseDir), outputDir, sourceEncoding)
+  def this(
+      baseDir: File,
+      outputDir: File,
+      sourceEncoding: Option[String],
+      recoverNoSourceRoot: BaseReportWriter.PathRecoverer
+  ) = {
+    this(Seq(baseDir), outputDir, sourceEncoding, recoverNoSourceRoot)
   }
 
   def write(coverage: Coverage): Unit = {
@@ -49,24 +60,26 @@ class CoberturaXmlWriter(
     </method>
   }
 
-  def klass(klass: MeasuredClass): Node = {
-    <class name={klass.fullClassName}
-           filename={relativeSource(klass.source)}
-           line-rate={DoubleFormat.twoFractionDigits(klass.statementCoverage)}
-           branch-rate={DoubleFormat.twoFractionDigits(klass.branchCoverage)}
-           complexity="0">
-      <methods>
-        {klass.methods.map(method)}
-      </methods>
-      <lines>
-        {
-          klass.statements.map(stmt => <line
-          number={stmt.line.toString}
-          hits={stmt.count.toString}
-          branch={stmt.branch.toString}/>)
-        }
-      </lines>
-    </class>
+  def klass(klass: MeasuredClass): Option[Node] = {
+    relativeSource(klass.source).map(sourcePath => {
+      <class name={klass.fullClassName}
+             filename={sourcePath}
+             line-rate={DoubleFormat.twoFractionDigits(klass.statementCoverage)}
+             branch-rate={DoubleFormat.twoFractionDigits(klass.branchCoverage)}
+             complexity="0">
+        <methods>
+          {klass.methods.map(method)}
+        </methods>
+        <lines>
+          {
+            klass.statements.map(stmt => <line
+            number={stmt.line.toString}
+            hits={stmt.count.toString}
+            branch={stmt.branch.toString}/>)
+          }
+        </lines>
+      </class>
+    })
   }
 
   def pack(pack: MeasuredPackage): Node = {
@@ -75,7 +88,7 @@ class CoberturaXmlWriter(
              branch-rate={DoubleFormat.twoFractionDigits(pack.branchCoverage)}
              complexity="0">
       <classes>
-        {pack.classes.map(klass)}
+        {pack.classes.flatMap(klass)}
       </classes>
     </package>
   }

--- a/reporter/src/test/scala/scoverage/reporter/TestUtils.scala
+++ b/reporter/src/test/scala/scoverage/reporter/TestUtils.scala
@@ -1,0 +1,43 @@
+package scoverage.reporter
+
+import scoverage.domain.Location
+import scoverage.domain.ClassType
+import scoverage.domain.Statement
+
+object TestUtils {
+  private var nextId = 0
+
+  def testLocation(
+      sourcePath: String,
+      className: String = s"T$nextId",
+      classType: ClassType = ClassType.Class
+  ): Location =
+    Location(
+      "scoverage.test",
+      className,
+      s"scoverage.test.$className",
+      classType,
+      "method",
+      sourcePath
+    )
+
+  def testStatement(
+      location: Location,
+      isBranch: Boolean = false,
+      invokeCount: Int = 0
+  ): Statement = {
+    nextId += 1
+    Statement(
+      location,
+      nextId,
+      10 + nextId,
+      50 + nextId,
+      nextId * 10,
+      nextId.toString,
+      "sym",
+      "",
+      isBranch,
+      invokeCount
+    )
+  }
+}


### PR DESCRIPTION
This introduce a "PathRecoverer" that can take action when a path is not in any source root. In particular, it can replace the path and allow to continue, or skip the element, or fail (and of course emit a warning, or whatever - but I didn't want to make the reporter itself handle logging, they will look better if handled from sbt, mill, etc.)

The next step is to use this in the sbt plugin, and then we can say goodbye to the "no source root found for $x" error!