### PR TITLE
Handle branches in anonymous function pattern matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.log
 
+# Build Server Protocol
+.bsp/
+
 # SBT specific
 target/
 project/boot/

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -660,7 +660,20 @@ class ScoverageInstrumentationComponent(
 
         // handle function bodies. This AST node corresponds to the following Scala code: vparams => body
         case f: Function =>
-          treeCopy.Function(tree, f.vparams, process(f.body))
+          f.body match {
+            case b: Match =>
+              // anonymous function bodies with pattern matching needs to account for branches
+              treeCopy.Function(
+                tree,
+                f.vparams,
+                treeCopy.Match(
+                  b,
+                  b.selector,
+                  transformCases(b.cases, branch = true)
+                )
+              )
+            case _ => treeCopy.Function(tree, f.vparams, process(f.body))
+          }
 
         case _: Ident => tree
 

--- a/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -130,13 +130,35 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     assert(!compiler.reporter.hasErrors)
     // should instrument:
     // the if clause,
-    // thenp block,
-    // thenp literal "1",
-    // elsep block,
-    // elsep literal "2",
+    // then block,
+    // then literal "1",
+    // else block,
+    // else literal "2",
     // case block "yes" literal
     // skip case block "yes" literal
     compiler.assertNMeasuredStatements(7)
+  }
+
+  test(
+    "scoverage should instrument anonymous function with pattern matching body"
+  ) {
+    val compiler = ScoverageCompiler.default
+    compiler.compileCodeSnippet(
+      """ object A {
+        |  def foo(a: List[Option[Int]]) = a.map {
+        |    case Some(value) => value + 1
+        |    case None => 0
+        |  }
+        |} """.stripMargin
+    )
+    assert(!compiler.reporter.hasErrors)
+    // should instrument:
+    // the def method entry,
+    // case Some,
+    // case block expression
+    // case none,
+    // case block literal "0"
+    compiler.assertNMeasuredStatements(5)
   }
 
   // https://github.com/scoverage/sbt-scoverage/issues/16
@@ -246,9 +268,9 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
 
     assert(!compiler.reporter.hasErrors)
     assert(!compiler.reporter.hasWarnings)
-    // should have 4 profiled statements: the outer apply, the true, the a < b, the false
+    // should have 7 profiled statements: the outer apply, and three pairs of case patterns & blocks
     // we are testing that we don't instrument the tuple2 call used here
-    compiler.assertNMeasuredStatements(4)
+    compiler.assertNMeasuredStatements(7)
   }
 
   test("scoverage should instrument all case statements in an explicit match") {

--- a/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -158,7 +158,11 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     // case block expression
     // case none,
     // case block literal "0"
-    compiler.assertNMeasuredStatements(5)
+
+    // account for canbuildfrom statement
+    val expectedStatementsCount =
+      if (ScoverageCompiler.ShortScalaVersion < "2.13") 6 else 5
+    compiler.assertNMeasuredStatements(expectedStatementsCount)
   }
 
   // https://github.com/scoverage/sbt-scoverage/issues/16


### PR DESCRIPTION
While adopting my previous contribution in #493, I was still finding case patterns not being counted as branches. This was only in anonymous functions, where the parameter is used as selector, e.g.:

```scala
(1 to 100).map {
  case i if i % 2 == 0 => true
  case _ => false
}
```

The `match` handling does not instrument the case statements when the selector gets generated. But anonymous functions are a special case because the case statements are written by the user.

The solution in this PR handles anonymous function case by checking if the function body itself is a match node in the AST.