### PR TITLE
Accept multiple phases instead of one

### DIFF
--- a/plugin/src/main/scala/scoverage/ScoverageOptions.scala
+++ b/plugin/src/main/scala/scoverage/ScoverageOptions.scala
@@ -27,8 +27,8 @@ object ScoverageOptions {
       "-P:scoverage:excludedPackages:<regex>;<regex>         semicolon separated list of regexs for packages to exclude",
       "-P:scoverage:excludedFiles:<regex>;<regex>            semicolon separated list of regexs for paths to exclude",
       "-P:scoverage:excludedSymbols:<regex>;<regex>          semicolon separated list of regexs for symbols to exclude",
-      "-P:scoverage:extraAfterPhase:<phaseName>              phase after which scoverage phase runs (must be after typer phase)",
-      "-P:scoverage:extraBeforePhase:<phaseName>             phase before which scoverage phase runs (must be before patmat phase)",
+      "-P:scoverage:extraAfterPhase:<phaseName>;<phaseName>  phase after which scoverage phase runs (must be after typer phase)",
+      "-P:scoverage:extraBeforePhase:<phaseName>;<phaseName> phase before which scoverage phase runs (must be before patmat phase)",
       "                                                      Any classes whose fully qualified name matches the regex will",
       "                                                      be excluded from coverage."
     ).mkString("\n")
@@ -72,12 +72,16 @@ object ScoverageOptions {
 
   def processPhaseOptions(
       opts: List[String]
-  ): (Option[String], Option[String]) = {
+  ): (Option[List[String]], Option[List[String]]) = {
 
-    val afterPhase: Option[String] =
-      opts.collectFirst { case ExtraAfterPhase(phase) => phase }
-    val beforePhase: Option[String] =
-      opts.collectFirst { case ExtraBeforePhase(phase) => phase }
+    val afterPhase: Option[List[String]] =
+      opts.collectFirst { case ExtraAfterPhase(phase) =>
+        phase.split(";").toList
+      }
+    val beforePhase: Option[List[String]] =
+      opts.collectFirst { case ExtraBeforePhase(phase) =>
+        phase.split(";").toList
+      }
 
     (afterPhase, beforePhase)
   }

--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -74,8 +74,8 @@ class ScoveragePlugin(val global: Global) extends Plugin {
 
 class ScoverageInstrumentationComponent(
     val global: Global,
-    extraAfterPhase: Option[String],
-    extraBeforePhase: Option[String]
+    extraAfterPhase: Option[List[String]],
+    extraBeforePhase: Option[List[String]]
 ) extends PluginComponent
     with TypingTransformers
     with Transform {
@@ -87,9 +87,9 @@ class ScoverageInstrumentationComponent(
 
   override val phaseName: String = ScoveragePlugin.phaseName
   override val runsAfter: List[String] =
-    List("typer") ::: extraAfterPhase.toList
+    List("typer") ::: extraAfterPhase.getOrElse(Nil)
   override val runsBefore: List[String] =
-    List("patmat") ::: extraBeforePhase.toList
+    List("patmat") ::: extraBeforePhase.getOrElse(Nil)
 
   /** Our options are not provided at construction time, but shortly after,
     * so they start as None.

--- a/plugin/src/test/scala/scoverage/ScoverageOptionsTest.scala
+++ b/plugin/src/test/scala/scoverage/ScoverageOptionsTest.scala
@@ -11,8 +11,8 @@ class ScoverageOptionsTest extends FunSuite {
     "excludedPackages:some.package;another.package*",
     "excludedFiles:*.proto;iHateThisFile.scala",
     "excludedSymbols:someSymbol;anotherSymbol;aThirdSymbol",
-    "extraAfterPhase:extarAfter",
-    "extraBeforePhase:extraBefore",
+    "extraAfterPhase:extarAfter;extraAfter2",
+    "extraBeforePhase:extraBefore;extraBefore2",
     "reportTestName"
   )
 


### PR DESCRIPTION
# Motivation

Ever since #164, we have some control over phase, `scoverage-instrument`. We can just specify which phase the `scoverage-instrument` should sit in by supplying a compiler option `-P:scoverage:extraBeforePhase:<phaseName>` and `-P:scoverage:extraAfterPhase:<phaseName>`.

However, while normally up to one customized phase is enough, my use case is somewhat peculiar. I was working on a personal project which relies on [chipsalliance/chisel](https://github.com/chipsalliance/chisel) and to generate coverage without any issue, `scoverage-instrument` must run before *two* phases, not just one.

That's because chisel's plugin generates additional AST on the fly. Here's an example:
```scala
else if (isData || isPrefixed) {
  val prefixed = q"chisel3.experimental.prefix.apply[$tpt](name=$prefix)(f=$newRHS)"

  val named =
    if (isNamedComp) {
      // Only name named components (not things that are merely prefixed)
      q"chisel3.internal.plugin.autoNameRecursively($str)($prefixed)"
    } else {
      prefixed
    }

  treeCopy.ValDef(dd, mods, name, tpt, localTyper.typed(named))
}
```
Source: https://github.com/chipsalliance/chisel/blob/v3.6.1/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala#L194

Without specifying any of `extraBeforePhase` and `extraAfterPhase`, scoverage plugin emits following warnings (on 1.9.0, now it's error afterwards).
```
[info] [warn] Could not instrument [Literal/null]. No pos.
[info] [warn] Could not instrument [Literal/null]. No pos.
[info] [warn] Could not instrument [Literal/null]. No pos.
[info] [warn] Could not instrument [Apply/method autoNameRecursively]. No pos.
[info] [warn] Could not instrument [Literal/null]. No pos.
[info] [warn] Could not instrument [Apply/method autoNameRecursively]. No pos.
[info] [warn] Could not instrument [Apply/method apply]. No pos.
[info] [warn] Could not instrument [Apply/method autoNameRecursively]. No pos.
```

As described above, the only way to solve this is putting `scoverage-instrument` ahead of chisel's phases, called `chiselbundlephase` and `chiselcomponent`.

I can't simply disable such plugins because they're simply indispensible to generate a hardware code. Before this pull request, I've devised a dummy plugin to workaround such ordering issue. However, that approach is only a temporary measure, so I decided to file this feature request as well.

# Change Summary

- Let user specify multiple phases via `-P` option.
  - Ex. `-P:scoverage:extraBeforePhase:chiselcomponent;chiselbundlephase`
  - Used `;` as a delimiter to match the style of other options like `excludedSymbols` and so on.

# Related issues / PRs

- #164 