### PR TITLE
bugfix: scoverage does not instrument pat-mat assignment properly

### DIFF
--- a/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
+++ b/plugin/src/main/scala/scoverage/ScoveragePlugin.scala
@@ -853,7 +853,10 @@ class ScoverageInstrumentationComponent(
           *
           * This will instrument the user expression (if-else with arrow calls).
           */
-        case v: ValDef if v.symbol.isSynthetic && v.rhs.pos.isDefined && containsNonSynthetic(v.rhs) =>
+        case v: ValDef
+            if v.symbol.isSynthetic && v.rhs.pos.isDefined && containsNonSynthetic(
+              v.rhs
+            ) =>
           treeCopy.ValDef(tree, v.mods, v.name, v.tpt, process(v.rhs))
 
         /** <synthetic> val default: A1 => B1 =

--- a/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
+++ b/plugin/src/test/scala/scoverage/PluginCoverageTest.scala
@@ -381,7 +381,9 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     compiler.assertNMeasuredStatements(11)
   }
 
-  test("plugin should handle return pattern matching assignment https://github.com/scoverage/scalac-scoverage-plugin/issues/123") {
+  test(
+    "plugin should handle return pattern matching assignment https://github.com/scoverage/scalac-scoverage-plugin/issues/123"
+  ) {
     val compiler = ScoverageCompiler.default
     compiler.compileCodeSnippet(
       """
@@ -396,15 +398,15 @@ class PluginCoverageTest extends FunSuite with MacroSupport {
     )
     assert(!compiler.reporter.hasErrors)
     assert(!compiler.reporter.hasWarnings)
-    /**
-     * WITHOUT the bugfix:
-     * 2 when assigning value to "a" and "b"
-     * 1 at the end of the function
-     * WITH the bugfix, it will additionally include
-     * 2 from then branch
-     * 2 from else branch
-     * 2 from synthetic code generated for pattern matching assignment
-     */
+
+    /** WITHOUT the bugfix:
+      * 2 when assigning value to "a" and "b"
+      * 1 at the end of the function
+      * WITH the bugfix, it will additionally include
+      * 2 from then branch
+      * 2 from else branch
+      * 2 from synthetic code generated for pattern matching assignment
+      */
     compiler.assertNMeasuredStatements(9)
   }
 


### PR DESCRIPTION
# Why

As mentioned in [this issue](https://github.com/scoverage/scalac-scoverage-plugin/issues/123), scoverage doesn't instrument its measure statement(s) into the RHS of pattern-matching assignment. This causes the coverage report to not include any of the user code inside that RHS and make the coverage score differs from the reality.

The root cause of this issue is due to the following match-case in `ScoveragePlugin.scala`:

```
case v: ValDef if v.symbol.isSynthetic => tree
```

Scala compiler compiles the pattern-matching assignment into the synthetic ValDef, so the above match-case causes scoverage to completely ignore that tree. For example:

**User code**
```
val (a, b) = {
    if (c) 1 -> 1 else 2 -> 2 // statements which should be instrumented
}
```

**Compiled code**
```
val x1 = (if (c) 1 -> 1 else 2 -> 2) match {
    case scala.Tuple2((a @ _), (b @ _)) => scala.Tuple2(a, b)
} // This is synthetic ValDef! Scoverage completely ignore this.
val a = x1._1
val b= x2._2
```

When scoverage encounters the `val x1 = ...`, it completely ignore this and doesn't instrument `if (c) 1 -> 1 else 2 -> 2`.

# What

This PR fixes this by adding an additional match-case specifically to handle this case:

```
case v: ValDef if v.symbol.isSynthetic && v.rhs.pos.isDefined && containsNonSynthetic(v.rhs) =>
          treeCopy.ValDef(tree, v.mods, v.name, v.tpt, process(v.rhs))
```

In the example, `val x1 = ...` will fall into this case since it's a synthetic code whose RHS contains some user code. With this fix, scoverage will now consider `if (c) 1 -> 1 else 2 -> 2` and include them in the coverage report.

# Note

For the above example, this fix also unintentionally introduce another 2 measure statements inside the `case scala.Tuple2((a @ _), (b @ _)) => scala.Tuple2(a, b)`. 

IMO, This is also a synthetic code and should not be included in the coverage report. However, I don't enough confidence to exclude this out since it might accidentally exclude some valid codes out of the report. And since the consequence of having this additional measure statements is just the dilution of the %coverage with 2 always-hit/always-miss statements. It's fine to just ignore them.
