### PR TITLE
Fix warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,7 @@ inThisBuild(
       "utf8"
     ),
     semanticdbEnabled := true,
-    semanticdbVersion := scalametaVersion,
-    scalafixScalaBinaryVersion := scalaBinaryVersion.value
+    semanticdbVersion := scalametaVersion
   )
 )
 


### PR DESCRIPTION
```
Warning: /home/runner/work/scalac-scoverage-plugin/scalac-scoverage-plugin/build.sbt:65: warning: value scalafixScalaBinaryVersion in object autoImport is deprecated (since 0.12.1): scalafixScalaBinaryVersion now follows scalaVersion by default
    scalafixScalaBinaryVersion := scalaBinaryVersion.value
    ^
```